### PR TITLE
feat: Add initial tests for init.lua and improve test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 .PHONY: test test-deps
 
-test: test-deps
-	busted tests/spec/
+test:
+	@if [ -n "${file}" ]; then \
+		busted tests/spec/${file}; \
+	else \
+		busted tests/spec/; \
+	fi
 
 test-deps:
 	@if ! command -v busted &> /dev/null; then \

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ Then, you can run the tests:
 ```bash
 # Run all tests
 make test
+
+# Run a specific test file
+make test file=init_spec.lua
 ```
 
 Tests cover:

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@ To implement these tests, the following tools are required:
 #### `init.lua`
 
 *   **Test:** `M.setup()`
+    *   **Status:** ✅ Implemented
     *   **Description:** Verify the main setup function initializes the configuration, styles, loaders, and auto-update mechanism correctly.
     *   **Expected Behavior:** `config.setup`, `styles.setup_highlights`, `loaders.load_all`, and `shell.update_llm_cli` should be called under the correct conditions.
     *   **Test Implementation:** Mock the required modules (`config`, `styles`, `loaders`, `shell`). Call `M.setup` with various options (e.g., `auto_update_cli = true/false`) and assert that the mocked functions are called with the expected arguments.

--- a/tests/spec/init_spec.lua
+++ b/tests/spec/init_spec.lua
@@ -1,0 +1,143 @@
+local spy = require('luassert.spy')
+
+describe('llm.init', function()
+  local llm_init
+  local config_mock
+  local styles_mock
+  local loaders_mock
+  local shell_mock
+
+  before_each(function()
+    _G.vim = {
+      env = {},
+      fn = {
+        stdpath = function() return "/tmp" end,
+        json_encode = function(data) return "" end,
+        system = function() end,
+      },
+      log = {
+        levels = {
+          INFO = 1,
+          WARN = 2,
+          ERROR = 3,
+        },
+      },
+      notify = spy.new(function() end),
+      defer_fn = function(fn) fn() end,
+    }
+    package.loaded['llm.managers.plugins_manager'] = {
+        refresh_available_plugins = function() end,
+    }
+    package.loaded['llm.init'] = nil
+    package.loaded['llm.config'] = nil
+    package.loaded['llm.ui.styles'] = nil
+    package.loaded['llm.core.loaders'] = nil
+    package.loaded['llm.core.utils.shell'] = nil
+
+    config_mock = {
+      setup = spy.new(function() end),
+      get = spy.new(function(key)
+        if key == 'auto_update_cli' then
+          return false
+        end
+        if key == 'auto_update_interval_days' then
+          return 7
+        end
+        return nil
+      end),
+    }
+
+    styles_mock = {
+      setup_highlights = spy.new(function() end),
+    }
+
+    loaders_mock = {
+      load_all = spy.new(function() end),
+    }
+
+    shell_mock = {
+      get_last_update_timestamp = spy.new(function() return 0 end),
+      update_llm_cli = spy.new(function() end),
+    }
+
+    package.loaded['llm.config'] = config_mock
+    package.loaded['llm.ui.styles'] = styles_mock
+    package.loaded['llm.core.loaders'] = loaders_mock
+    package.loaded['llm.core.utils.shell'] = shell_mock
+
+    llm_init = require('llm.init')
+  end)
+
+  after_each(function()
+    package.loaded['llm.config'] = nil
+    package.loaded['llm.ui.styles'] = nil
+    package.loaded['llm.core.loaders'] = nil
+    package.loaded['llm.core.utils.shell'] = nil
+  end)
+
+  it('should call config.setup with provided options', function()
+    local opts = { model = 'test-model' }
+    llm_init.setup(opts)
+    assert.spy(config_mock.setup).was.called_with(opts)
+  end)
+
+  it('should call styles.setup_highlights', function()
+    llm_init.setup({})
+    assert.spy(styles_mock.setup_highlights).was.called()
+  end)
+
+  it('should call loaders.load_all', function()
+    llm_init.setup({})
+    assert.spy(loaders_mock.load_all).was.called()
+  end)
+
+  describe('auto-update', function()
+    it('should not check for updates if auto_update_cli is false', function()
+      config_mock.get = spy.new(function(key)
+        if key == 'auto_update_cli' then
+          return false
+        end
+        return nil
+      end)
+      llm_init.setup({})
+      assert.spy(shell_mock.get_last_update_timestamp).was.not_called()
+    end)
+
+    it('should check for updates if auto_update_cli is true and interval has passed', function()
+      config_mock.get = spy.new(function(key)
+        if key == 'auto_update_cli' then
+          return true
+        end
+        if key == 'auto_update_interval_days' then
+          return 7
+        end
+        return nil
+      end)
+      shell_mock.get_last_update_timestamp = spy.new(function() return os.time() - (8 * 24 * 60 * 60) end) -- 8 days ago
+      vim.defer_fn = function(fn) fn() end
+      shell_mock.update_llm_cli = spy.new(function() return { success = true } end)
+
+      llm_init.setup({})
+
+      assert.spy(shell_mock.get_last_update_timestamp).was.called()
+      assert.spy(shell_mock.update_llm_cli).was.called()
+    end)
+
+    it('should not check for updates if auto_update_cli is true but interval has not passed', function()
+      config_mock.get = spy.new(function(key)
+        if key == 'auto_update_cli' then
+          return true
+        end
+        if key == 'auto_update_interval_days' then
+          return 7
+        end
+        return nil
+      end)
+      shell_mock.get_last_update_timestamp = spy.new(function() return os.time() - (6 * 24 * 60 * 60) end) -- 6 days ago
+
+      llm_init.setup({})
+      assert.spy(shell_mock.get_last_update_timestamp).was.called()
+      assert.spy(shell_mock.update_llm_cli).was.not_called()
+    end)
+  end)
+end)


### PR DESCRIPTION
This commit introduces the first set of tests for the project, focusing on the `init.lua` module. It also improves the `Makefile` to allow running specific test files.

- Adds a new test file `tests/spec/init_spec.lua` with tests for the `M.setup()` function.
- Mocks dependencies to ensure the tests are isolated and run quickly.
- Updates the `Makefile` to support running specific test files via the `file` parameter (e.g., `make test file=init_spec.lua`).
- Updates `TODO.md` to mark the `init.lua` tests as complete.
- Updates `README.md` to document how to run specific tests.