### PR TITLE
feat: Implement tests for api.lua

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,12 +25,14 @@ To implement these tests, the following tools are required:
 #### `api.lua`
 
 *   **Test:** `M.setup()`
+    *   **Status:** ✅ Implemented
     *   **Description:** Ensure the API's setup function correctly calls the configuration setup.
     *   **Expected Behavior:** `config.setup` should be called with the provided options.
     *   **Test Implementation:** Mock `require('llm.config').setup` and assert that it is called when `M.setup` is invoked.
 *   **Test:** `M.version()`
     *   **Omission Justification:** This is a one-line function that returns a value from another module. It will be implicitly tested via the tests for the `config` module.
 *   **Test:** All facade functions (`get_manager`, `command`, `prompt`, etc.)
+    *   **Status:** ✅ Implemented
     *   **Description:** Verify that all functions from the `facade` module are correctly exposed through the `api` module via a loop.
     *   **Expected Behavior:** Calling a function on the `api` module should call the corresponding function on the `facade` module.
     *   **Test Implementation:** Mock the `facade` module. Iterate through its functions, call them via the `api` module, and assert that the corresponding mock in the `facade` was called.

--- a/tests/spec/api_spec.lua
+++ b/tests/spec/api_spec.lua
@@ -1,0 +1,59 @@
+local spy = require('luassert.spy')
+
+describe('llm.api', function()
+  local api
+  local config_mock
+
+  before_each(function()
+    package.loaded['llm.config'] = nil
+
+    config_mock = {
+      setup = spy.new(function() end),
+    }
+
+    package.loaded['llm.config'] = config_mock
+
+    api = require('llm.api')
+  end)
+
+  after_each(function()
+    package.loaded['llm.config'] = nil
+  end)
+
+  it('should call config.setup with provided options', function()
+    local opts = { model = 'test-model' }
+    api.setup(opts)
+    assert.spy(config_mock.setup).was.called_with(opts)
+  end)
+
+  describe('facade functions', function()
+    local facade_mock
+
+    before_each(function()
+      facade_mock = {
+        get_manager = spy.new(function() end),
+        command = spy.new(function() end),
+        prompt = spy.new(function() end),
+        prompt_with_selection = spy.new(function() end),
+        prompt_with_current_file = spy.new(function() end),
+        toggle_unified_manager = spy.new(function() end),
+      }
+      package.loaded['llm.facade'] = facade_mock
+      -- Rerequire api to get the mocked facade
+      package.loaded['llm.api'] = nil
+      api = require('llm.api')
+    end)
+
+    after_each(function()
+      package.loaded['llm.facade'] = nil
+    end)
+
+    it('should expose all facade functions', function()
+      for name, func in pairs(facade_mock) do
+        assert.is_function(api[name], "Expected api." .. name .. " to be a function")
+        api[name]("test_arg")
+        assert.spy(func).was.called_with("test_arg")
+      end
+    end)
+  end)
+end)


### PR DESCRIPTION
This commit introduces tests for the `api.lua` module, ensuring that the setup function and all facade functions are working as expected. The tests have been implemented using the `busted` testing framework and are located in `tests/spec/api_spec.lua`.

The `TODO.md` file has been updated to reflect the completion of these tests.