### PR TITLE
feat: Add more rigorous tests for llm_cli.lua

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -189,7 +189,8 @@ To implement these tests, the following tools are required:
 #### `data/llm_cli.lua`
 
 *   **Test:** `M.run_llm_command()`
-    *   **Description:** Ensure it prepends "llm " to the command and calls the shell wrapper.
+    *   **Status:** ✅ Implemented
+    *   **Description:** Ensure it prepends "llm " to the command and calls the shell wrapper. Handles empty and special character commands.
     *   **Expected Behavior:** `shell.safe_shell_command` should be called with the correct full command string.
     *   **Test Implementation:** Mock `require('llm.core.utils.shell').safe_shell_command`. Call `M.run_llm_command("models list")` and assert the mock was called with `"llm models list"`.
 

--- a/tests/spec/core/data/llm_cli_spec.lua
+++ b/tests/spec/core/data/llm_cli_spec.lua
@@ -1,0 +1,49 @@
+-- tests/spec/core/data/llm_cli_spec.lua
+
+describe("llm.core.data.llm_cli", function()
+  local llm_cli
+  local shell
+
+  before_each(function()
+    -- Create a mock for the shell module
+    shell = {
+      safe_shell_command = function() end,
+    }
+    package.loaded['llm.core.utils.shell'] = shell
+
+    -- Reload the llm_cli module to use the mock
+    package.loaded['llm.core.data.llm_cli'] = nil
+    llm_cli = require('llm.core.data.llm_cli')
+  end)
+
+  after_each(function()
+    -- Restore original modules
+    package.loaded['llm.core.utils.shell'] = nil
+    package.loaded['llm.core.data.llm_cli'] = nil
+  end)
+
+  it("should prepend 'llm ' to the command and call shell.safe_shell_command", function()
+    -- Spy on the safe_shell_command function
+    local spy = spy.on(shell, "safe_shell_command")
+
+    -- Call the function to be tested
+    local command = "models list"
+    llm_cli.run_llm_command(command)
+
+    -- Assert that the spy was called with the correct argument
+    assert.spy(spy).was.called_with("llm " .. command)
+  end)
+
+  it("should handle an empty command", function()
+    local spy = spy.on(shell, "safe_shell_command")
+    llm_cli.run_llm_command("")
+    assert.spy(spy).was.called_with("llm ")
+  end)
+
+  it("should handle a command with special characters", function()
+    local spy = spy.on(shell, "safe_shell_command")
+    local command = "prompt 'hello world'"
+    llm_cli.run_llm_command(command)
+    assert.spy(spy).was.called_with("llm " .. command)
+  end)
+end)


### PR DESCRIPTION
This commit introduces more rigorous tests for the `llm_cli.lua` module, ensuring that the `run_llm_command` function correctly formats and dispatches commands to the shell wrapper. The new tests cover empty commands and commands with special characters.