### PR TITLE
feat: add tests for models_io.lua

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,11 +54,7 @@ By implementing this testing strategy, we can significantly improve the test cov
 
 #### 2. `managers/custom_openai.lua` (`tests/spec/managers/custom_openai_spec.lua`) - Done
 
-#### 3. `managers/models_io.lua` (`tests/spec/managers/models_io_spec.lua`)
-
-*   **All functions**
-    *   **Test:** should call `llm_cli.run_llm_command` with the correct command string.
-        *   **Implementation:** Mock `llm_cli.run_llm_command`. Call each function in `models_io.lua` and assert that the mock was called with the expected command string.
+#### 3. `managers/models_io.lua` (`tests/spec/managers/models_io_spec.lua`) - Done
 
 #### 4. `managers/models_manager.lua` (`tests/spec/managers/models_manager_spec.lua`)
 

--- a/tests/spec/managers/models_io_spec.lua
+++ b/tests/spec/managers/models_io_spec.lua
@@ -1,0 +1,101 @@
+-- tests/spec/managers/models_io_spec.lua
+
+require("spec_helper")
+
+describe("llm.managers.models_io", function()
+  local models_io
+  local llm_cli
+
+  before_each(function()
+    _G.package = require('package')
+    package.loaded["llm.managers.models_io"] = nil
+    package.loaded["llm.core.data.llm_cli"] = nil
+
+    llm_cli = require("llm.core.data.llm_cli")
+    models_io = require("llm.managers.models_io")
+  end)
+
+  after_each(function()
+    package.loaded["llm.managers.models_io"] = nil
+    package.loaded["llm.core.data.llm_cli"] = nil
+    _G.package = nil
+  end)
+
+  describe("get_models_from_cli()", function()
+    it("should call llm_cli.run_llm_command with the correct command string", function()
+      -- Mock llm_cli.run_llm_command
+      local run_llm_command_spy = spy.on(llm_cli, "run_llm_command")
+
+      -- Call the function
+      models_io.get_models_from_cli()
+
+      -- Assertions
+      assert.spy(run_llm_command_spy).was.called_with("models list --json")
+    end)
+  end)
+
+  describe("get_default_model_from_cli()", function()
+    it("should call llm_cli.run_llm_command with the correct command string", function()
+      -- Mock llm_cli.run_llm_command
+      local run_llm_command_spy = spy.on(llm_cli, "run_llm_command")
+
+      -- Call the function
+      models_io.get_default_model_from_cli()
+
+      -- Assertions
+      assert.spy(run_llm_command_spy).was.called_with("default")
+    end)
+  end)
+
+  describe("set_default_model_in_cli()", function()
+    it("should call llm_cli.run_llm_command with the correct command string", function()
+      -- Mock llm_cli.run_llm_command
+      local run_llm_command_spy = spy.on(llm_cli, "run_llm_command")
+
+      -- Call the function
+      models_io.set_default_model_in_cli("test-model")
+
+      -- Assertions
+      assert.spy(run_llm_command_spy).was.called_with("default test-model")
+    end)
+  end)
+
+  describe("get_aliases_from_cli()", function()
+    it("should call llm_cli.run_llm_command with the correct command string", function()
+      -- Mock llm_cli.run_llm_command
+      local run_llm_command_spy = spy.on(llm_cli, "run_llm_command")
+
+      -- Call the function
+      models_io.get_aliases_from_cli()
+
+      -- Assertions
+      assert.spy(run_llm_command_spy).was.called_with("aliases list --json")
+    end)
+  end)
+
+  describe("set_alias_in_cli()", function()
+    it("should call llm_cli.run_llm_command with the correct command string", function()
+      -- Mock llm_cli.run_llm_command
+      local run_llm_command_spy = spy.on(llm_cli, "run_llm_command")
+
+      -- Call the function
+      models_io.set_alias_in_cli("test-alias", "test-model")
+
+      -- Assertions
+      assert.spy(run_llm_command_spy).was.called_with("aliases set test-alias test-model")
+    end)
+  end)
+
+  describe("remove_alias_in_cli()", function()
+    it("should call llm_cli.run_llm_command with the correct command string", function()
+      -- Mock llm_cli.run_llm_command
+      local run_llm_command_spy = spy.on(llm_cli, "run_llm_command")
+
+      -- Call the function
+      models_io.remove_alias_in_cli("test-alias")
+
+      -- Assertions
+      assert.spy(run_llm_command_spy).was.called_with("aliases remove 'test-alias'")
+    end)
+  end)
+end)


### PR DESCRIPTION
This commit adds tests for all functions in `lua/llm/managers/models_io.lua`.

The tests mock the `llm_cli.run_llm_command` function and assert that it is called with the correct command string for each function in the `models_io` module.

The `spec_helper.lua` file is now used to set up the test environment, which simplifies the test file and avoids mocking the same objects in multiple places.

The `TODO.md` file has been updated to reflect the completion of these tests.