### PR TITLE
feat(tests): add tests for models_manager

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,21 +56,7 @@ By implementing this testing strategy, we can significantly improve the test cov
 
 #### 3. `managers/models_io.lua` (`tests/spec/managers/models_io_spec.lua`) - Done
 
-#### 4. `managers/models_manager.lua` (`tests/spec/managers/models_manager_spec.lua`)
-
-*   **`get_available_models()`**
-    *   **Test:** should parse the output from `llm-cli` correctly.
-        *   **Implementation:** Mock `llm_cli.run_llm_command` to return a sample output string. Call `get_available_models` and assert that the returned table is structured correctly.
-    *   **Test:** should cache the models.
-        *   **Implementation:** Mock `llm_cli.run_llm_command` and `cache.get`/`cache.set`. Call `get_available_models` twice and assert that `llm_cli.run_llm_command` was only called once.
-*   **`is_model_available(model_line)`**
-    *   **Test:** should return `true` for an available model.
-        *   **Implementation:** Mock `get_available_providers` to return a table indicating that the provider is available. Call `is_model_available` with a model from that provider and assert that it returns `true`.
-    *   **Test:** should return `false` for an unavailable model.
-        *   **Implementation:** Mock `get_available_providers` to return a table indicating that the provider is *not* available. Call `is_model_available` with a model from that provider and assert that it returns `false`.
-*   **`set_default_model(model_name)`, `set_model_alias(alias, model)`, `remove_model_alias(alias)`**
-    *   **Test:** should call the corresponding function in `models_io.lua`.
-        *   **Implementation:** Mock the corresponding function in `models_io.lua`. Call the `models_manager` function and assert that the mock was called with the correct arguments.
+#### 4. `managers/models_manager.lua` (`tests/spec/managers/models_manager_spec.lua`) - Done
 
 #### 5. `managers/fragments_manager.lua` (`tests/spec/managers/fragments_manager_spec.lua`)
 

--- a/lua/llm/managers/models_manager.lua
+++ b/lua/llm/managers/models_manager.lua
@@ -43,7 +43,7 @@ function M.reload_custom_openai_models()
 end
 
 -- Get available providers with valid API keys
-local function get_available_providers()
+function M.get_available_providers()
   local keys_manager = require('llm.managers.keys_manager')
   local plugins_manager = require('llm.managers.plugins_manager')
 
@@ -62,7 +62,7 @@ end
 
 -- Check if a specific model is available (used when setting default)
 function M.is_model_available(model_line)
-  local providers = get_available_providers()
+  local providers = M.get_available_providers()
   local model_name = M.extract_model_name(model_line)
 
   if config.get("debug") then
@@ -380,23 +380,18 @@ function M.generate_models_list()
     }
 
     -- Check for duplicates before adding to the provider list
-    if is_custom then
-      if processed_custom_model_ids[model_id] then
-        if config.get("debug") then
-          vim.notify("Skipping duplicate custom model entry for ID: " .. model_id, vim.log.levels.DEBUG)
-        end
-        goto next_model_line                        -- Skip adding this duplicate entry
-      else
+    if not (is_custom and processed_custom_model_ids[model_id]) then
+      if is_custom then
         processed_custom_model_ids[model_id] = true -- Mark this ID as processed
       end
-    end
 
-    if not providers[provider_key] then
-      providers[provider_key] = {}
+      if not providers[provider_key] then
+        providers[provider_key] = {}
+      end
+      table.insert(providers[provider_key], entry)
+    elseif config.get("debug") then
+      vim.notify("Skipping duplicate custom model entry for ID: " .. model_id, vim.log.levels.DEBUG)
     end
-    table.insert(providers[provider_key], entry)
-
-    ::next_model_line::
   end
 
   local model_data = {}       -- Stores detailed info keyed by model_id

--- a/tests/spec/managers/models_manager_spec.lua
+++ b/tests/spec/managers/models_manager_spec.lua
@@ -1,0 +1,122 @@
+-- tests/spec/managers/models_manager_spec.lua
+require('spec_helper')
+local models_manager = require('llm.managers.models_manager')
+local llm_cli = require('llm.core.data.llm_cli')
+local cache = require('llm.core.data.cache')
+local models_io = require('llm.managers.models_io')
+
+describe('models_manager', function()
+  describe('get_available_models', function()
+    it('should parse the output from llm-cli correctly', function()
+      -- Mock the llm_cli.run_llm_command function
+      llm_cli.run_llm_command = function()
+        return 'gpt-4\ngpt-3.5-turbo'
+      end
+
+      local models = models_manager.get_available_models()
+
+      -- Assert that the models are parsed correctly
+      local expected_models = {
+        { provider = 'Other', id = 'gpt-4', name = 'gpt-4' },
+        { provider = 'Other', id = 'gpt-3.5-turbo', name = 'gpt-3.5-turbo' },
+      }
+      assert.are.same(expected_models, models)
+    end)
+
+    it('should cache the models', function()
+      -- Mock the llm_cli.run_llm_command and cache.get/cache.set functions
+      local llm_cli_call_count = 0
+      llm_cli.run_llm_command = function()
+        llm_cli_call_count = llm_cli_call_count + 1
+        return 'gpt-4\ngpt-3.5-turbo'
+      end
+
+      local cache_data = nil
+      cache.get = function()
+        return cache_data
+      end
+      cache.set = function(key, value)
+        cache_data = value
+      end
+
+      -- Call get_available_models twice
+      models_manager.get_available_models()
+      models_manager.get_available_models()
+
+      -- Assert that llm_cli.run_llm_command was only called once
+      assert.are.equal(1, llm_cli_call_count)
+    end)
+  end)
+
+  describe('is_model_available', function()
+    it('should return true for an available model', function()
+      -- Mock get_available_providers to return a table indicating that the provider is available
+      local original_get_available_providers = models_manager.get_available_providers
+      models_manager.get_available_providers = function()
+        return {
+          OpenAI = true,
+        }
+      end
+
+      local result = models_manager.is_model_available('OpenAI Chat: gpt-4')
+      assert.is_true(result)
+
+      -- Restore the original function
+      models_manager.get_available_providers = original_get_available_providers
+    end)
+
+    it('should return false for an unavailable model', function()
+      -- Mock get_available_providers to return a table indicating that the provider is not available
+      local original_get_available_providers = models_manager.get_available_providers
+      models_manager.get_available_providers = function()
+        return {
+          OpenAI = false,
+        }
+      end
+
+      local result = models_manager.is_model_available('OpenAI Chat: gpt-4')
+      assert.is_false(result)
+
+      -- Restore the original function
+      models_manager.get_available_providers = original_get_available_providers
+    end)
+  end)
+
+  describe('delegation to models_io', function()
+    it('should call set_default_model_in_cli in models_io', function()
+      -- Mock the models_io.set_default_model_in_cli function
+      local models_io_call_args
+      models_io.set_default_model_in_cli = function(model_name)
+        models_io_call_args = { model_name = model_name }
+        return true
+      end
+
+      models_manager.set_default_model('gpt-4')
+      assert.are.same({ model_name = 'gpt-4' }, models_io_call_args)
+    end)
+
+    it('should call set_alias_in_cli in models_io', function()
+      -- Mock the models_io.set_alias_in_cli function
+      local models_io_call_args
+      models_io.set_alias_in_cli = function(alias, model)
+        models_io_call_args = { alias = alias, model = model }
+        return true
+      end
+
+      models_manager.set_model_alias('my-alias', 'gpt-4')
+      assert.are.same({ alias = 'my-alias', model = 'gpt-4' }, models_io_call_args)
+    end)
+
+    it('should call remove_alias_in_cli in models_io', function()
+      -- Mock the models_io.remove_alias_in_cli function
+      local models_io_call_args
+      models_io.remove_alias_in_cli = function(alias)
+        models_io_call_args = { alias = alias }
+        return true
+      end
+
+      models_manager.remove_model_alias('my-alias')
+      assert.are.same({ alias = 'my-alias' }, models_io_call_args)
+    end)
+  end)
+end)

--- a/tests/spec/spec_helper.lua
+++ b/tests/spec/spec_helper.lua
@@ -21,9 +21,39 @@ _G.vim = {
     end
     return a
   end,
+  tbl_isempty = function(tbl)
+    return next(tbl) == nil
+  end,
   fn = {
     system = function() end,
     executable = function() return 1 end,
     stdpath = function() return '/tmp' end,
+    json_encode = function(tbl)
+      -- A simple json encoder for testing purposes
+      local json = '{'
+      local first = true
+      for k, v in pairs(tbl) do
+        if not first then
+          json = json .. ','
+        end
+        first = false
+        json = json .. '"' .. tostring(k) .. '":'
+        if type(v) == 'string' then
+          json = json .. '"' .. v .. '"'
+        else
+          json = json .. tostring(v)
+        end
+      end
+      json = json .. '}'
+      return json
+    end,
+    json_decode = function(json)
+      -- A simple json decoder for testing purposes
+      local tbl = {}
+      for k, v in json:gmatch('"([^"]+)":"([^"]+)"') do
+        tbl[k] = v
+      end
+      return tbl
+    end,
   },
 }


### PR DESCRIPTION
Adds a new test suite for the `models_manager` module, covering the following functionality:
- `get_available_models()`: parsing and caching
- `is_model_available()`: checking for available and unavailable models
- `set_default_model()`, `set_model_alias()`, `remove_model_alias()`: delegation to `models_io`

Refactors `models_manager` to allow mocking of `get_available_providers` and fixes a syntax error.

Updates `spec_helper` to include mocks for `vim.fn.json_encode`, `vim.fn.json_decode`, and `vim.tbl_isempty`.