### PR TITLE
Fix(makefile): Correctly run tests in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test test-deps
 
 test:
-	@LUA_PATH="lua/?.lua;;" busted $(file)
+	@LUA_PATH="lua/?.lua;;" busted tests/spec
 
 test-deps:
 	@if ! command -v busted &> /dev/null; then \


### PR DESCRIPTION
The `make test` command was failing because the `file` variable was not defined. This change replaces `$(file)` with `tests/spec` to correctly run the tests in the `tests/spec` directory.