### PR TITLE
feat: Open scratch buffer in a vsplit and enter insert mode

### DIFF
--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -191,6 +191,8 @@ function M.dispatch_command(subcmd, ...)
     elseif subcmd == "toggle" then
       local unified_manager = require('llm.ui.unified_manager')
       return unified_manager.toggle(args[1] or "")
+    elseif subcmd == "" then
+        return ui.create_prompt_buffer()
     else
       -- Default case: treat as direct prompt
       return M.prompt(subcmd, args[1] or {})

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -173,6 +173,11 @@ describe('llm.commands', function()
         nvim_buf_set_option = spy.new(function() end),
         nvim_buf_set_name = spy.new(function() end),
         nvim_buf_set_lines = spy.new(function() end),
+        nvim_get_current_buf = spy.new(function() end),
+        nvim_create_augroup = spy.new(function() end),
+        nvim_create_autocmd = spy.new(function() end),
+        nvim_create_buf = spy.new(function() end),
+        nvim_open_win = spy.new(function() end),
       }
       _G.vim.notify = spy.new(function() end)
       -- We need to reload the modules to use the mocked vim object

--- a/tests/spec/core/utils/ui_spec.lua
+++ b/tests/spec/core/utils/ui_spec.lua
@@ -3,32 +3,43 @@ require('tests.spec.spec_helper')
 describe('llm.core.utils.ui', function()
   local ui_utils = require('llm.core.utils.ui')
 
-  describe('create_split_buffer()', function()
-    it('should create a split buffer', function()
-      local create_buf_spy = spy.new(function() return 1 end)
-      local open_win_spy = spy.new(function() end)
+  describe('create_prompt_buffer()', function()
+    it('should create a prompt buffer', function()
+      local cmd_spy = spy.new(function() end)
+      local get_current_buf_spy = spy.new(function() return 1 end)
+      local set_lines_spy = spy.new(function() end)
+      local create_augroup_spy = spy.new(function() return 1 end)
+      local create_autocmd_spy = spy.new(function() end)
 
+      -- Mock vim.cmd and vim.api
+      vim.cmd = cmd_spy
       ui_utils.set_api({
-        nvim_create_buf = create_buf_spy,
-        nvim_open_win = open_win_spy,
-        nvim_buf_set_option = function() end,
+        nvim_get_current_buf = get_current_buf_spy,
+        nvim_buf_set_lines = set_lines_spy,
+        nvim_create_augroup = create_augroup_spy,
+        nvim_create_autocmd = create_autocmd_spy,
       })
 
-      ui_utils.create_split_buffer('test')
+      ui_utils.create_prompt_buffer()
 
-      assert.spy(create_buf_spy).was.called_with(false, true)
-      assert.spy(open_win_spy).was.called()
+      assert.spy(cmd_spy).was.called_with('vnew')
+      assert.spy(cmd_spy).was.called_with('startinsert')
+      assert.spy(get_current_buf_spy).was.called()
+      assert.spy(set_lines_spy).was.called()
+      assert.spy(create_augroup_spy).was.called()
+      assert.spy(create_autocmd_spy).was.called()
     end)
   end)
 
   describe('buffer content', function()
     it('should create a buffer with content', function()
       local create_buf_spy = spy.new(function() return 1 end)
+      local open_win_spy = spy.new(function() end)
       local set_lines_spy = spy.new(function() end)
 
       ui_utils.set_api({
         nvim_create_buf = create_buf_spy,
-        nvim_open_win = function() end,
+        nvim_open_win = open_win_spy,
         nvim_buf_set_option = function() end,
         nvim_buf_set_name = function() end,
         nvim_buf_set_lines = set_lines_spy,
@@ -37,6 +48,7 @@ describe('llm.core.utils.ui', function()
       ui_utils.create_buffer_with_content('hello', 'test_buffer', 'markdown')
 
       assert.spy(create_buf_spy).was.called()
+      assert.spy(open_win_spy).was.called()
       assert.spy(set_lines_spy).was.called_with(1, 0, -1, false, { 'hello' })
     end)
 

--- a/tests/spec/scratch_buffer_save_spec.lua
+++ b/tests/spec/scratch_buffer_save_spec.lua
@@ -1,0 +1,93 @@
+require('tests.spec.spec_helper')
+
+describe('llm.commands', function()
+  local commands
+  local config_mock
+  local job_mock
+
+  before_each(function()
+    -- Mock the vim object
+    _G.vim = {
+      fn = {
+        shellescape = spy.new(function(str)
+          return str
+        end),
+        stdpath = spy.new(function()
+            return "/tmp"
+        end),
+      },
+      api = {
+        nvim_buf_get_lines = spy.new(function()
+          return { 'test prompt' }
+        end),
+        nvim_get_current_buf = spy.new(function()
+          return 1
+        end),
+        nvim_buf_get_name = spy.new(function()
+          return 'LLM_Scratch'
+        end),
+        nvim_buf_is_valid = spy.new(function()
+          return true
+        end),
+        nvim_buf_set_lines = spy.new(function() end),
+        nvim_create_augroup = spy.new(function() end),
+        nvim_create_autocmd = spy.new(function() end),
+        nvim_buf_set_option = spy.new(function() end),
+        nvim_buf_set_name = spy.new(function() end),
+        nvim_create_buf = spy.new(function() end),
+        nvim_open_win = spy.new(function() end),
+      },
+      notify = spy.new(function() end),
+      cmd = spy.new(function() end),
+      list_extend = function(t1, t2)
+        for _, v in ipairs(t2) do
+          table.insert(t1, v)
+        end
+      end,
+    }
+
+    config_mock = {
+      get = spy.new(function(key)
+        if key == 'model' then
+          return 'test-model'
+        end
+        return nil
+      end),
+    }
+    package.loaded['llm.config'] = config_mock
+
+    job_mock = {
+      run = spy.new(function() end),
+    }
+    package.loaded['llm.core.utils.job'] = job_mock
+
+    package.loaded['llm.commands'] = nil
+    commands = require('llm.commands')
+  end)
+
+  after_each(function()
+    package.loaded['llm.config'] = nil
+    package.loaded['llm.core.utils.job'] = nil
+    _G.vim = nil
+  end)
+
+  it('should call llm with buffer content on BufWriteCmd', function()
+    local get_lines_spy = spy.new(function()
+        return { "Enter your prompt here and then save and close the buffer to continue.", "test prompt" }
+    end)
+    _G.vim.api.nvim_buf_get_lines = get_lines_spy
+
+    local prompt_spy = spy.on(commands, 'prompt')
+
+    -- To simulate the save, we need to get the callback from the autocmd
+    local create_autocmd_spy = spy.new(function(event, opts)
+        opts.callback()
+    end)
+    _G.vim.api.nvim_create_autocmd = create_autocmd_spy
+
+    local ui_utils = require('llm.core.utils.ui')
+    ui_utils.create_prompt_buffer()
+
+    assert.spy(prompt_spy).was.called_with('test prompt')
+  end)
+end)

--- a/tests/spec/scratch_buffer_spec.lua
+++ b/tests/spec/scratch_buffer_spec.lua
@@ -1,0 +1,33 @@
+require('tests.spec.spec_helper')
+
+describe('llm.core.utils.ui', function()
+  local ui_utils = require('llm.core.utils.ui')
+
+  describe('create_prompt_buffer()', function()
+    it('should create a prompt buffer', function()
+        local cmd_spy = spy.new(function() end)
+        local get_current_buf_spy = spy.new(function() return 1 end)
+        local set_lines_spy = spy.new(function() end)
+        local create_augroup_spy = spy.new(function() return 1 end)
+        local create_autocmd_spy = spy.new(function() end)
+
+        -- Mock vim.cmd and vim.api
+        vim.cmd = cmd_spy
+        ui_utils.set_api({
+            nvim_get_current_buf = get_current_buf_spy,
+            nvim_buf_set_lines = set_lines_spy,
+            nvim_create_augroup = create_augroup_spy,
+            nvim_create_autocmd = create_autocmd_spy,
+        })
+
+        ui_utils.create_prompt_buffer()
+
+        assert.spy(cmd_spy).was.called_with('vnew')
+        assert.spy(cmd_spy).was.called_with('startinsert')
+        assert.spy(get_current_buf_spy).was.called()
+        assert.spy(set_lines_spy).was.called()
+        assert.spy(create_augroup_spy).was.called()
+        assert.spy(create_autocmd_spy).was.called()
+    end)
+  end)
+end)


### PR DESCRIPTION
The scratch buffer now opens in a vertical split, and the cursor is automatically placed in insert mode, ready for you to type your prompt. A prompt is also displayed in the buffer to guide you.

A `BufWriteCmd` autocommand is added to the scratch buffer to automatically call the `llm` command with the content of the buffer when it is saved. The prompt line is excluded from the content passed to the `llm` command.