### PR TITLE
fix(test): Resolve ui_spec.lua failure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,11 +36,11 @@ The current test failures indicate a brittle mocking setup, primarily due to inc
 
 These failures are likely indicative of actual bugs or incorrect logic in the plugin and should be addressed after the test environment is stable.
 
-- [ ] **Investigate and Fix: `tests/spec/core/utils/ui_spec.lua` Failure - `create_chat_buffer()` arguments mismatch.**
-    - [ ] **Problem:** `llm.core.utils.ui create_chat_buffer() should create and configure the chat buffer correctly` - `Function was never called with matching arguments.`
-    - [ ] **Evaluation:** This is a legitimate test failure, likely due to incorrect mocking or a change in the `create_chat_buffer` function's signature or behavior. It is not outdated or brittle, but rather a sign that the test setup or the function under test needs adjustment.
-    - [ ] **Action:** Analyze `ui_spec.lua` and `lua/llm/core/utils/ui.lua` to understand why the mock for `create_chat_buffer` is not being called with the expected arguments. Adjust the mock or the test to match the actual function call.
-    - [ ] **Test:** Rerun the specific test to confirm the fix.
+- [x] **Investigate and Fix: `tests/spec/core/utils/ui_spec.lua` Failure - `create_chat_buffer()` arguments mismatch.**
+    - [x] **Problem:** `llm.core.utils.ui create_chat_buffer() should create and configure the chat buffer correctly` - `Function was never called with matching arguments.`
+    - [x] **Evaluation:** This is a legitimate test failure, likely due to incorrect mocking or a change in the `create_chat_buffer` function's signature or behavior. It is not outdated or brittle, but rather a sign that the test setup or the function under test needs adjustment.
+    - [x] **Action:** Analyze `ui_spec.lua` and `lua/llm/core/utils/ui.lua` to understand why the mock for `create_chat_buffer` is not being called with the expected arguments. Adjust the mock or the test to match the actual function call.
+    - [x] **Test:** Rerun the specific test to confirm the fix.
 
 - [ ] **Investigate and Fix: `tests/spec/plugin_spec.lua` Failure - `:LLM command handler not calling `chat.start_chat()`**
     - [ ] **Problem:** `plugin/llm.lua :LLM command handler should call chat.start_chat() when called with no arguments` - `Expected to be called >0 time(s), but was called 0 time(s)`

--- a/lua/llm/core/utils/ui.lua
+++ b/lua/llm/core/utils/ui.lua
@@ -92,11 +92,26 @@ function M.create_chat_buffer()
     filetype = "markdown"
   })
 
+  -- Set the content of the buffer to a prompt
+  local prompt_text = {
+    '--- User Prompt ---',
+    'Enter your prompt below and press <Enter> to submit.',
+    '-------------------',
+    ''
+  }
+  api.nvim_buf_set_lines(buf, 0, -1, false, prompt_text)
+
   -- Set up keymap for <Enter>
   api.nvim_buf_set_keymap(buf, 'i', '<Enter>', '<Cmd>lua require("llm.chat").send_prompt()<CR>',
     { noremap = true, silent = true })
   -- Add a keymap for closing the buffer
   api.nvim_buf_set_keymap(buf, 'n', 'q', '<Cmd>bd<CR>', { noremap = true, silent = true })
+
+  -- Move the cursor to the end of the prompt
+  api.nvim_win_set_cursor(0, { 4, 0 })
+
+  -- Switch to insert mode
+  vim.cmd('startinsert')
 
   return buf
 end

--- a/temp_yaml.yaml
+++ b/temp_yaml.yaml
@@ -1,7 +1,0 @@
-key1: value1
-key2:
-  nested_key1: nested_value1
-  nested_key2: nested_value2
-key3:
-  - item1
-  - item2


### PR DESCRIPTION
The test for `create_chat_buffer()` in `tests/spec/core/utils/ui_spec.lua` was failing because the function was not setting the initial buffer content as expected.

This commit fixes the issue by adding the necessary logic to `create_chat_buffer()` in `lua/llm/core/utils/ui.lua` to:

- Set the initial prompt text in the chat buffer.
- Position the cursor at the end of the prompt.
- Switch to insert mode.

The corresponding test now passes, and the `TODO.md` file has been updated to reflect this change.