### PR TITLE
feat(text): implement text.wrap function and tests

### DIFF
--- a/lua/llm/core/utils/text.lua
+++ b/lua/llm/core/utils/text.lua
@@ -109,4 +109,34 @@ function M.parse_simple_yaml(filepath)
   return data
 end
 
+function M.wrap(text, width, indent)
+  indent = indent or ''
+  width = width or 80
+
+  local words = {}
+  for word in text:gmatch('%S+') do
+    table.insert(words, word)
+  end
+
+  if #words == 0 then
+    return ''
+  end
+
+  local lines = {}
+  local current_line = indent .. words[1]
+
+  for i = 2, #words do
+    local word = words[i]
+    if #current_line + 1 + #word > width then
+      table.insert(lines, current_line)
+      current_line = indent .. word
+    else
+      current_line = current_line .. ' ' .. word
+    end
+  end
+  table.insert(lines, current_line)
+
+  return table.concat(lines, '\n')
+end
+
 return M

--- a/tests/spec/core/utils/text_spec.lua
+++ b/tests/spec/core/utils/text_spec.lua
@@ -95,4 +95,50 @@ key3:
       os.remove('temp_yaml.yaml')
     end)
   end)
+
+  describe('wrap()', function()
+    it('should not wrap a line shorter than the width', function()
+      local text = 'hello world'
+      local wrapped = text_utils.wrap(text, 80)
+      assert.are.equal('hello world', wrapped)
+    end)
+
+    it('should wrap a long line', function()
+      local text = 'this is a long line of text that should be wrapped'
+      local wrapped = text_utils.wrap(text, 20)
+      local expected = 'this is a long line\nof text that should\nbe wrapped'
+      assert.are.equal(expected, wrapped)
+    end)
+
+    it('should wrap a long line with an indent', function()
+      local text = 'this is a long line of text that should be wrapped'
+      local wrapped = text_utils.wrap(text, 30, '  ')
+      local expected = '  this is a long line of text\n  that should be wrapped'
+      assert.are.equal(expected, wrapped)
+    end)
+
+    it('should handle a word longer than the width', function()
+      local text = 'thisisaverylongword'
+      local wrapped = text_utils.wrap(text, 10)
+      assert.are.equal('thisisaverylongword', wrapped)
+    end)
+
+    it('should handle an empty string', function()
+      local text = ''
+      local wrapped = text_utils.wrap(text, 80)
+      assert.are.equal('', wrapped)
+    end)
+
+    it('should handle a string with only spaces', function()
+      local text = '   '
+      local wrapped = text_utils.wrap(text, 80)
+      assert.are.equal('', wrapped)
+    end)
+
+    it('should handle a string shorter than the width', function()
+      local text = 'a short string'
+      local wrapped = text_utils.wrap(text, 80)
+      assert.are.equal('a short string', wrapped)
+    end)
+  end)
 end)


### PR DESCRIPTION
Implemented the `text.wrap` function in `lua/llm/core/utils/text.lua` to wrap text to a specified width with an optional indent.

Added a comprehensive test suite for the `text.wrap` function in `tests/spec/core/utils/text_spec.lua` to cover various use cases, including:
- Wrapping long lines
- Handling indentation
- Handling words longer than the wrap width
- Handling empty and whitespace-only strings