### PR TITLE
feat: Add tools_manager.lua for llm tools integration

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -52,7 +52,7 @@
 - [Tech Debt 5]: Custom YAML parsing in `custom_openai.lua` might be fragile.
 - [Gap 15]: Missing support for explicitly setting the API key per command (`--key`).
 ## Ranked Backlog
-1. [Gap 1.1] - [High Impact/Medium Effort] - Create core `tools_manager.lua` to interface with the llm CLI to list and execute tools.
+1. [Gap 1.1b] - [High Impact/Medium Effort] - Add functionality to `tools_manager.lua` to execute tools.
 1. [Gap 1.2] - [High Impact/Medium Effort] - Create UI components (`tools_view.lua`) and integrate with `unified_manager.lua` and `facade.lua`.
 1. [Gap 1.3] - [Medium Impact/Low Effort] - Update `:LLM` command in `commands.lua` and `api.lua` to parse and pass tool arguments.
 1. [Gap 1.4] - [High Impact/Low Effort] - Write tests for the new tools features in `tests/spec/tools_spec.lua` and add documentation (`CRITICAL-005-add-tools-support.md`).

--- a/lua/llm/managers/tools_manager.lua
+++ b/lua/llm/managers/tools_manager.lua
@@ -1,0 +1,34 @@
+-- llm/managers/tools_manager.lua - Tool management for llm-nvim
+-- License: Apache 2.0
+
+local M = {}
+
+local llm_cli = require('llm.core.data.llm_cli')
+
+function M.get_tools()
+  local tools_json = llm_cli.run_llm_command('tools list --json')
+
+  if not tools_json or tools_json == "" then
+    return {}
+  end
+
+  local ok, tools_data = pcall(vim.fn.json_decode, tools_json)
+  if not ok or type(tools_data) ~= "table" then
+    vim.notify("Failed to parse tools JSON: " .. tostring(tools_json), vim.log.levels.ERROR)
+    return {}
+  end
+
+  -- Some tools list might just be the list or nested under "tools"
+  local tools_list = {}
+  if tools_data.tools and type(tools_data.tools) == "table" then
+    tools_list = tools_data.tools
+  else
+    tools_list = tools_data
+  end
+
+  return tools_list
+end
+
+M.__name = 'llm.managers.tools_manager'
+
+return M

--- a/tests/spec/managers/tools_manager_spec.lua
+++ b/tests/spec/managers/tools_manager_spec.lua
@@ -1,0 +1,59 @@
+-- tests/spec/managers/tools_manager_spec.lua
+require('spec_helper')
+local tools_manager = require('llm.managers.tools_manager')
+local llm_cli = require('llm.core.data.llm_cli')
+local mock_vim = require('mock_vim')
+
+describe("tools_manager", function()
+  before_each(function()
+    _G.vim = mock_vim
+    stub(llm_cli, "run_llm_command")
+
+    -- Mock json_decode in vim.fn for these tests
+    stub(vim.fn, "json_decode")
+  end)
+
+  after_each(function()
+    llm_cli.run_llm_command:revert()
+    vim.fn.json_decode:revert()
+  end)
+
+  it("get_tools parses JSON output correctly", function()
+    local sample_json = [[{"tools": [{"name": "llm_time", "description": "Returns the current time", "plugin": "llm.default_plugins.default_tools"}]}]]
+    llm_cli.run_llm_command.returns(sample_json)
+    vim.fn.json_decode.returns({
+      tools = {
+        {
+          name = "llm_time",
+          description = "Returns the current time",
+          plugin = "llm.default_plugins.default_tools"
+        }
+      }
+    })
+
+    local tools = tools_manager.get_tools()
+
+    assert.spy(llm_cli.run_llm_command).was.called_with('tools list --json')
+    assert.are.same(1, #tools)
+    assert.are.same("llm_time", tools[1].name)
+    assert.are.same("Returns the current time", tools[1].description)
+  end)
+
+  it("get_tools handles empty output gracefully", function()
+    llm_cli.run_llm_command.returns("")
+    local tools = tools_manager.get_tools()
+    assert.are.same({}, tools)
+  end)
+
+  it("get_tools handles invalid JSON gracefully", function()
+    llm_cli.run_llm_command.returns("invalid json output")
+    vim.fn.json_decode.invokes(function() error("Invalid JSON") end)
+    stub(vim, "notify")
+
+    local tools = tools_manager.get_tools()
+
+    assert.are.same({}, tools)
+    assert.spy(vim.notify).was.called()
+    vim.notify:revert()
+  end)
+end)


### PR DESCRIPTION
This pull request addresses the first part of CRITICAL-005: Add Tools Support (Gap 1). It implements the core `tools_manager.lua` to interface with the llm CLI and list tools. 
It also removes Gap 1.1 from BACKLOG.md and adds a subtask for Gap 1.1b (executing tools).

---
*PR created automatically by Jules for task [3534575834860399015](https://jules.google.com/task/3534575834860399015) started by @julwrites*