### PR TITLE
docs: update backlog with repository audit

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,82 +2,47 @@
 - Prompting (`llm prompt`): Execute a prompt.
 - Ongoing Chat (`llm chat`): Hold an ongoing chat with a model.
 - Model Aliases (`llm aliases`): Manage model aliases.
-- Collections (`llm collections`): View and manage collections of embeddings.
-- Embeddings (`llm embed`, `llm embed-multi`): Embed text and store or return the result.
-- Embedding Models (`llm embed-models`): Manage available embedding models.
-- Fragments (`llm fragments`): Manage fragments that are stored in the database.
-- Key Management (`llm keys`): Manage stored API keys for different models.
-- Logs (`llm logs`): Tools for exploring logged prompts and responses.
-- Models (`llm models`): Manage available models.
-- Plugins (`llm plugins`, `llm install`, `llm uninstall`): Manage installed plugins.
-- Schemas (`llm schemas`): Manage stored schemas.
-- Similar (`llm similar`): Return top N similar IDs from a collection.
+- Models (`llm models`): View available models.
 - Templates (`llm templates`): Manage stored prompt templates.
-- Tools (`llm tools`): Manage tools that can be made available to LLMs.
 - Multi-modal attachments (`-a` / `--attachment`): Call models with attachments like images.
-- Explicit Attachment Mimetypes (`--at` / `--attachment-type`): Attachment with explicit mimetype.
 - Tools / Function Calling Options (`-T`, `--tool`, `--functions`, `--td`, `--ta`, `--cl`): Make tools available to the model.
 - Extractions (`-x` / `--extract`, `--xl` / `--extract-last`): Extract content of fenced code blocks.
 - Model Options (`-o` / `--option`): key/value options for the model.
 - Template Parameters (`-p` / `--param`): Parameters for template.
 - Usage tracking (`-u` / `--usage`): Show token usage.
 - System Fragments (`--sf` / `--system-fragment`): Fragment to add to system prompt.
-- Schema Execution (`--schema`, `--schema-multi`): JSON schema to use for prompt results.
 - Continue Prompt Conversation (`-c`, `--continue`, `--cid`, `--conversation`): Continue the most recent or specific conversation.
-- Logging Options (`--log`, `-n` / `--no-log`, `-d` / `--database`): Control SQLite logging behavior.
 - Query Selection (`-q` / `--query`): Use first model matching strings.
 - Save as Template (`--save`): Save prompt with a template name.
 - Async Execution (`--async`): Run prompt asynchronously.
 - Stream Control (`--no-stream`): Do not stream output.
-- Key Configuration (`--key`): API key to use for prompt and chat.
+
 ## Gaps & Tech Debt
-- [Gap 1]: Missing support for Tools / Function Calling (`-T`, `--tool`, `--functions`, `tools`, `--td`, `--ta`, `--cl`).
-- [Gap 2]: Missing support for Embeddings (`embed`, `embed-models`, `embed-multi`, `collections`, `similar`).
-- [Gap 3]: Missing support for Multi-modal attachments (`-a`, `--attachment`, `--at`, `--attachment-type`).
-- [Gap 4]: Missing integration with Logs (`logs`) for exploring past prompts and responses, along with logging options (`--log`, `--no-log`, `--database`).
-- [Gap 5]: Missing support for Extractions (`-x`, `--extract`, `--xl`, `--extract-last`) in prompt command execution (only implemented in template creation/saving, but not in general `llm prompt` calls).
-- [Gap 6]: Missing support for Model Options (`-o`, `--option`).
-- [Gap 7]: Missing support for Template Parameters (`-p`, `--param`).
-- [Gap 8]: Missing support for Usage tracking (`-u`, `--usage`).
-- [Gap 9]: Missing support for System Fragments (`--sf`, `--system-fragment`).
-- [Gap 10]: Missing support for Schemas in prompt generation (`--schema`, `--schema-multi`).
-- [Gap 11]: Missing support for Continue Conversation in standard prompt command (`-c`, `--continue`, `--cid`, `--conversation`).
-- [Gap 12]: Missing support for Stream Control (`--no-stream`) and Async Execution (`--async`).
-- [Gap 13]: Missing support for Query Selection (`-q`, `--query`).
-- [Gap 14]: Missing support for Save as Template (`--save`) directly from prompt command.
-- [Tech Debt 1]: Increase code coverage from ~46.57% to 80% (currently below target, tracked in CODE-QUALITY-005).
-- [Tech Debt 2]: Improve async job handling robustness and line buffering edge cases in `lua/llm/core/utils/job.lua`.
-- [Tech Debt 3]: Optimize Lua/Python interoperability for smoother command line execution.
-- [Tech Debt 4]: `M.interactive_prompt_with_fragments` in `fragments_manager.lua` is not fully tested.
-- [Tech Debt 5]: Custom YAML parsing in `custom_openai.lua` might be fragile.
-- [Gap 15]: Missing support for explicitly setting the API key per command (`--key`).
+- [Gap 1]: Missing support for Tools / Function Calling (`-T`, `--tool`, `--functions`, `--td`, `--ta`, `--cl`).
+- [Gap 2]: Missing support for Multi-modal attachments (`-a`, `--attachment`).
+- [Gap 3]: Missing support for Extractions (`-x`, `--extract`, `--xl`, `--extract-last`) in general prompt generation.
+- [Gap 4]: Missing support for Model Options (`-o`, `--option`).
+- [Gap 5]: Missing support for Template Parameters (`-p`, `--param`).
+- [Gap 6]: Missing support for Usage tracking (`-u`, `--usage`).
+- [Gap 7]: Missing support for System Fragments (`--sf`, `--system-fragment`).
+- [Gap 8]: Missing support for Continue Conversation (`-c`, `--continue`, `--cid`, `--conversation`).
+- [Gap 9]: Missing support for Query Selection (`-q`, `--query`).
+- [Gap 10]: Missing support for Stream Control (`--no-stream`) and Async Execution (`--async`).
+- [Tech Debt 1]: Increase overall code coverage.
+- [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
+- [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `fragments_manager.lua`.
+
 ## Ranked Backlog
-1. [Gap 1.1b] - [High Impact/Medium Effort] - Add functionality to `tools_manager.lua` to execute tools.
-1. [Gap 1.2] - [High Impact/Medium Effort] - Create UI components (`tools_view.lua`) and integrate with `unified_manager.lua` and `facade.lua`.
-1. [Gap 1.3] - [Medium Impact/Low Effort] - Update `:LLM` command in `commands.lua` and `api.lua` to parse and pass tool arguments.
-1. [Gap 1.4] - [High Impact/Low Effort] - Write tests for the new tools features in `tests/spec/tools_spec.lua` and add documentation (`CRITICAL-005-add-tools-support.md`).
-2. [Gap 2.1] - [Medium Impact/High Effort] - Implement Embeddings support: Create `embeddings_manager.lua`.
-2. [Gap 2.2] - [Medium Impact/High Effort] - Implement Embeddings support: Create `embeddings_view.lua` and integrate into `unified_manager.lua`.
-2. [Gap 2.3] - [Medium Impact/High Effort] - Implement Embeddings support: Add `:LLMEmbed` command.
-2. [Gap 2.4] - [Medium Impact/High Effort] - Implement Embeddings support: Add `:LLMSimilar` command.
-3. [Tech Debt 1.1] - [High Impact/High Effort] - Increase Code Coverage to 80%: Write tests for `lua/llm/managers/custom_openai.lua`.
-3. [Tech Debt 1.2] - [High Impact/High Effort] - Increase Code Coverage to 80%: Write tests for `lua/llm/managers/templates_manager.lua`.
-3. [Tech Debt 1.3] - [High Impact/High Effort] - Increase Code Coverage to 80%: Write tests for `lua/llm/managers/models_manager.lua`.
-3. [Tech Debt 1.4] - [High Impact/High Effort] - Increase Code Coverage to 80%: Write tests for other managers (`schemas_manager`, `plugins_manager`, `fragments_manager`, etc).
-4. [Tech Debt 2] - [High Impact/Low Effort] - Improve async job handling robustness in `job.lua` (e.g. process exiting mid-buffer).
-5. [Tech Debt 3] - [Medium Impact/Medium Effort] - Optimize Lua/Python interoperability for smoother command line execution.
-6. [Gap 3] - [Medium Impact/Medium Effort] - Implement Multi-modal attachments support (e.g., attaching images to prompts if terminal/UI supports it, or passing paths).
-7. [Gap 6] - [Medium Impact/Low Effort] - Implement Model Options (`-o`/`--option`) support.
-8. [Gap 7] - [Medium Impact/Low Effort] - Implement Template Parameters (`-p`/`--param`) support.
-9. [Gap 5] - [Medium Impact/Low Effort] - Implement Extractions (`-x`/`--extract`, `--xl`/`--extract-last`) support in `lua/llm/commands.lua` for prompt generation.
-10. [Gap 4] - [Low Impact/Low Effort] - Expose `logs` command functionally to explore past prompts/responses inside Neovim and configure Logging Options.
-11. [Gap 8] - [Low Impact/Low Effort] - Expose token usage tracking (`-u`/`--usage`).
-12. [Gap 10] - [Low Impact/Low Effort] - Implement Schemas in prompt generation (`--schema`, `--schema-multi`).
-13. [Gap 9] - [Low Impact/Low Effort] - Implement System Fragments (`--sf`, `--system-fragment`).
-14. [Gap 11] - [Low Impact/Low Effort] - Implement Continue Conversation in standard prompt command (`-c`, `--continue`, `--cid`, `--conversation`).
-15. [Gap 12] - [Low Impact/Low Effort] - Implement Stream Control (`--no-stream`) and Async Execution (`--async`).
-16. [Gap 13] - [Low Impact/Low Effort] - Implement Query Selection (`-q`, `--query`).
-17. [Gap 14] - [Low Impact/Low Effort] - Implement Save as Template (`--save`) directly from prompt command.
-18. [Tech Debt 4] - [Low Impact/Medium Effort] - Write tests for `M.interactive_prompt_with_fragments` in `fragments_manager.lua`.
-19. [Tech Debt 5] - [Low Impact/Medium Effort] - Refactor custom YAML parsing in `custom_openai.lua` to be more robust.
-20. [Gap 15] - [Medium Impact/Low Effort] - Support passing API keys via `--key` to override the configured/default key.
+1. [Gap 1] - [High Impact/Medium Effort] - Implement functionality to support executing and integrating tools into the LLM prompts.
+2. [Tech Debt 1] - [High Impact/High Effort] - Increase overall code coverage across managers by adding comprehensive unit testing.
+3. [Gap 3] - [High Impact/Low Effort] - Implement Extractions (`-x`, `--xl`) support for targeted code block extraction from model responses.
+4. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+5. [Gap 2] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types.
+6. [Gap 4] - [Medium Impact/Low Effort] - Expose Model Options (`-o`) configuration per model or prompt.
+7. [Gap 5] - [Medium Impact/Low Effort] - Support dynamic Template Parameters (`-p`).
+8. [Gap 8] - [Medium Impact/Low Effort] - Add functionality to Continue Conversations (`-c`) easily from previous prompt sessions.
+9. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments`.
+10. [Gap 6] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`) visually after execution.
+11. [Gap 7] - [Low Impact/Low Effort] - Allow composing System Fragments (`--sf`).
+12. [Gap 9] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`).
+13. [Gap 10] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).


### PR DESCRIPTION
This updates `BACKLOG.md` to cleanly present an audit of the upstream `llm` CLI vs the `llm-nvim` implementation, focusing strictly on editor-relevant capabilities.

---
*PR created automatically by Jules for task [2118785266508651689](https://jules.google.com/task/2118785266508651689) started by @julwrites*