### PR TITLE
Update BACKLOG.md with Schema Gap and Tech Debt Subtasks

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -16,6 +16,7 @@
 - Save as Template (`--save`): Save prompt with a template name.
 - Async Execution (`--async`): Run prompt asynchronously.
 - Stream Control (`--no-stream`): Do not stream output.
+- Schemas (`llm schemas`): Manage stored schemas.
 
 ## Gaps & Tech Debt
 - [Gap 1]: Missing support for Tools / Function Calling (`-T`, `--tool`, `--functions`, `--td`, `--ta`, `--cl`).
@@ -28,6 +29,7 @@
 - [Gap 8]: Missing support for Continue Conversation (`-c`, `--continue`, `--cid`, `--conversation`).
 - [Gap 9]: Missing support for Query Selection (`-q`, `--query`).
 - [Gap 10]: Missing support for Stream Control (`--no-stream`) and Async Execution (`--async`).
+- [Gap 11]: Missing support for Schema Options (`--schema`, `--schema-multi`) in prompting.
 - [Tech Debt 1]: Increase overall code coverage. Test coverage is currently at ~46%, well below the 80% target. Managers like models_manager, templates_manager, schemas_manager, keys_manager, fragments_manager, custom_openai, plugins_manager all have less than 50% coverage.
 - [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `fragments_manager.lua`.
@@ -36,7 +38,9 @@
 1. [Gap 1 - Subtask 1] - [High Impact/Medium Effort] - Implement UI and Manager for Tools (tools_manager.lua, tools_view.lua, unified_manager.lua).
 1. [Gap 1 - Subtask 2] - [High Impact/Medium Effort] - Integrate tool support into command execution and prompting in `commands.lua` and `plugin/llm.lua`.
 1. [Gap 1 - Subtask 3] - [High Impact/Medium Effort] - Add tests for Tools UI and Tools command execution.
-2. [Tech Debt 1] - [High Impact/High Effort] - Increase overall code coverage across managers by adding comprehensive unit testing, targeting the >80% goal.
+2. [Tech Debt 1 - Subtask 1] - [High Impact/High Effort] - Increase test coverage for models_manager, templates_manager, and schemas_manager.
+2. [Tech Debt 1 - Subtask 2] - [High Impact/High Effort] - Increase test coverage for keys_manager, fragments_manager.
+2. [Tech Debt 1 - Subtask 3] - [High Impact/High Effort] - Increase test coverage for custom_openai, plugins_manager.
 3. [Gap 3] - [High Impact/Low Effort] - Implement Extractions (`-x`, `--xl`) support for targeted code block extraction from model responses.
 4. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
 5. [Gap 2] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`).
@@ -48,3 +52,4 @@
 11. [Gap 7] - [Low Impact/Low Effort] - Allow composing System Fragments (`--sf`).
 12. [Gap 9] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`).
 13. [Gap 10] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+14. [Gap 11] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.


### PR DESCRIPTION
This commit updates `BACKLOG.md` to reflect a recent audit against the upstream `llm` CLI tool. It correctly identifies the missing "Schemas" feature and its related CLI options, categorizing it properly within the ranked backlog. Additionally, it breaks down the monolithic code coverage tech debt into three manageable sub-tasks while strictly adhering to the requested Markdown format.

---
*PR created automatically by Jules for task [5419744178581958606](https://jules.google.com/task/5419744178581958606) started by @julwrites*