### PR TITLE
Implement UI and Manager for Tools

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,7 +35,6 @@
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `fragments_manager.lua`.
 
 ## Ranked Backlog
-1. [Gap 1 - Subtask 1] - [High Impact/Medium Effort] - Implement UI and Manager for Tools (tools_manager.lua, tools_view.lua, unified_manager.lua).
 1. [Gap 1 - Subtask 2] - [High Impact/Medium Effort] - Integrate tool support into command execution and prompting in `commands.lua` and `plugin/llm.lua`.
 1. [Gap 1 - Subtask 3] - [High Impact/Medium Effort] - Add tests for Tools UI and Tools command execution.
 2. [Tech Debt 1 - Subtask 1] - [High Impact/High Effort] - Increase test coverage for models_manager, templates_manager, and schemas_manager.

--- a/lua/llm/managers/tools_manager.lua
+++ b/lua/llm/managers/tools_manager.lua
@@ -4,6 +4,9 @@
 local M = {}
 
 local llm_cli = require('llm.core.data.llm_cli')
+local api = vim.api
+local styles = require('llm.ui.styles')
+local tools_view = require('llm.ui.views.tools_view')
 
 function M.get_tools()
   local tools_json = llm_cli.run_llm_command('tools list --json')
@@ -27,6 +30,94 @@ function M.get_tools()
   end
 
   return tools_list
+end
+
+-- Populate the buffer with tool management content
+function M.populate_tools_buffer(bufnr)
+  local tools = M.get_tools()
+
+  local lines = {
+    "# Tool Management",
+    "",
+    "Navigate: [M]odels [P]lugins [K]eys [F]ragments",
+    "Actions: [v]iew details [q]uit",
+    "──────────────────────────────────────────────────────────────",
+    "",
+  }
+
+  local tool_data = {}
+  local line_to_tool = {}
+
+  if #tools == 0 then
+    table.insert(lines, "No tools found.")
+  else
+    table.insert(lines, "Available Tools:")
+    table.insert(lines, "----------------")
+    local current_line = #lines + 1
+
+    for _, tool in ipairs(tools) do
+      table.insert(lines, "- " .. tool.name .. ": " .. (tool.description or "No description"))
+      tool_data[tool.name] = tool
+      line_to_tool[current_line] = tool.name
+      current_line = current_line + 1
+    end
+  end
+
+  api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  styles.setup_highlights()
+  styles.setup_buffer_syntax(bufnr)
+
+  vim.b[bufnr].line_to_tool = line_to_tool
+  vim.b[bufnr].tool_data = tool_data
+
+  return line_to_tool, tool_data
+end
+
+-- Setup keymaps for the tools management buffer
+function M.setup_tools_keymaps(bufnr, manager_module)
+  manager_module = manager_module or M
+
+  local function set_keymap(mode, lhs, rhs)
+    api.nvim_buf_set_keymap(bufnr, mode, lhs, rhs, { noremap = true, silent = true })
+  end
+
+  -- View tool details
+  set_keymap('n', 'v', string.format([[<Cmd>lua require('%s').view_tool_details_under_cursor(%d)<CR>]], manager_module.__name or 'llm.managers.tools_manager', bufnr))
+end
+
+-- View tool details
+function M.view_tool_details_under_cursor(bufnr)
+  local tool_name, tool_info = M.get_tool_info_under_cursor(bufnr)
+  if not tool_name then
+    vim.notify("No tool found under cursor", vim.log.levels.WARN)
+    return
+  end
+
+  -- Open details view
+  tools_view.show_details(tool_name, tool_info, M)
+end
+
+-- Get tool info under cursor
+function M.get_tool_info_under_cursor(bufnr)
+  local current_line = api.nvim_win_get_cursor(0)[1]
+  local line_to_tool = vim.b[bufnr].line_to_tool
+  local tool_data = vim.b[bufnr].tool_data
+
+  if not line_to_tool or not tool_data then
+    return nil, nil
+  end
+
+  local tool_name = line_to_tool[current_line]
+  if tool_name and tool_data[tool_name] then
+    return tool_name, tool_data[tool_name]
+  end
+
+  return nil, nil
+end
+
+-- Main function to open tools view
+function M.manage_tools()
+  require('llm.ui.unified_manager').open_specific_manager("Tools")
 end
 
 M.__name = 'llm.managers.tools_manager'

--- a/lua/llm/ui/unified_manager.lua
+++ b/lua/llm/ui/unified_manager.lua
@@ -15,6 +15,7 @@ local keys_manager = require('llm.managers.keys_manager')
 local fragments_manager = require('llm.managers.fragments_manager')
 local templates_manager = require('llm.managers.templates_manager')
 local schemas_manager = require('llm.managers.schemas_manager')
+local tools_manager = require('llm.managers.tools_manager')
 
 -- State for the unified window
 local state = {
@@ -54,6 +55,12 @@ local views = {
     setup_keymaps = fragments_manager.setup_fragments_keymaps,
     title = "Fragments",
     manager_module = fragments_manager,
+  },
+  Tools = {
+    populate = tools_manager.populate_tools_buffer,
+    setup_keymaps = tools_manager.setup_tools_keymaps,
+    title = "Tools",
+    manager_module = tools_manager,
   },
 }
 
@@ -95,6 +102,7 @@ local function setup_common_keymaps(bufnr)
   set_keymap('n', 'P', '<Cmd>lua require("llm.ui.unified_manager").switch_view("Plugins")<CR>')
   set_keymap('n', 'K', '<Cmd>lua require("llm.ui.unified_manager").switch_view("Keys")<CR>')
   set_keymap('n', 'F', '<Cmd>lua require("llm.ui.unified_manager").switch_view("Fragments")<CR>')
+  set_keymap('n', 'T', '<Cmd>lua require("llm.ui.unified_manager").switch_view("Tools")<CR>')
 end
 
 -- Switch the view within the unified window

--- a/lua/llm/ui/views/tools_view.lua
+++ b/lua/llm/ui/views/tools_view.lua
@@ -1,0 +1,55 @@
+-- llm/ui/views/tools_view.lua - UI functions for tool management
+-- License: Apache 2.0
+
+local M = {}
+
+local ui = require('llm.core.utils.ui')
+local api = vim.api
+
+-- Displays detailed information about a tool in a floating window.
+function M.show_details(tool_name, tool_info, manager_module)
+  local content_buf = api.nvim_create_buf(false, true)
+  api.nvim_buf_set_option(content_buf, 'buftype', 'nofile')
+  api.nvim_buf_set_option(content_buf, 'bufhidden', 'wipe')
+  api.nvim_buf_set_option(content_buf, 'swapfile', false)
+  api.nvim_buf_set_name(content_buf, 'Tool Details: ' .. tool_name)
+
+  local winid = ui.create_floating_window(content_buf, 'Tool Details')
+
+  local lines = {
+    "# Tool: " .. tool_name,
+    "",
+    "Description: " .. (tool_info.description or "None"),
+    "Plugin: " .. (tool_info.plugin or "None"),
+    "",
+    "## Arguments:",
+  }
+
+  if tool_info.arguments and tool_info.arguments.properties and not vim.tbl_isempty(tool_info.arguments.properties) then
+    for arg_name, arg_data in pairs(tool_info.arguments.properties) do
+      table.insert(lines, "- " .. arg_name .. ": " .. (arg_data.description or "") .. " (Type: " .. (arg_data.type or "unknown") .. ")")
+    end
+  else
+    table.insert(lines, "None")
+  end
+
+  table.insert(lines, "")
+  table.insert(lines, "Press [q]uit or [Esc] to close")
+
+  api.nvim_buf_set_lines(content_buf, 0, -1, false, lines)
+
+  -- Setup syntax highlights if needed
+  local styles = require('llm.ui.styles')
+  pcall(styles.setup_buffer_syntax, content_buf)
+
+  api.nvim_buf_set_option(content_buf, 'modifiable', false)
+
+  local function set_keymap(mode, lhs, rhs)
+    api.nvim_buf_set_keymap(content_buf, mode, lhs, rhs, { noremap = true, silent = true })
+  end
+
+  set_keymap('n', 'q', '<Cmd>close<CR>')
+  set_keymap('n', '<Esc>', '<Cmd>close<CR>')
+end
+
+return M


### PR DESCRIPTION
This commit implements the UI and manager logic for handling Tools within the llm-nvim plugin.

- Added `tools_view.lua` to display tool details.
- Extended `tools_manager.lua` to populate the buffer with available tools and handle selection/viewing details.
- Integrated the new Tools manager and view into `unified_manager.lua` and added the `[T]ools` keymap.
- Removed the completed task from the Ranked Backlog.

---
*PR created automatically by Jules for task [11603474458669634748](https://jules.google.com/task/11603474458669634748) started by @julwrites*