### PR TITLE
feat: expose model options configuration

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -37,20 +37,19 @@
 - [Gap 12]: Missing support for specifying an API key per request (`--key`).
 
 ## Ranked Backlog
-1. [Gap 2] - [Medium Impact/Low Effort] - Expose Model Options (`-o`, `--option`) configuration per model or prompt.
-2. [Gap 3] - [Medium Impact/Low Effort] - Support dynamic Template Parameters (`-p`, `--param`).
-3. [Gap 6] - [Medium Impact/Low Effort] - Add functionality to Continue Conversations (`-c`, `--continue`, `--cid`, `--conversation`) easily from previous prompt sessions.
-4. [Gap 9] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
-5. [Gap 11] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
-6. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
-7. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-8. [Tech Debt 1 - Subtask 1] - [High Impact/High Effort] - Increase test coverage for models_manager, templates_manager, and schemas_manager.
-9. [Tech Debt 1 - Subtask 2] - [High Impact/High Effort] - Increase test coverage for keys_manager, fragments_manager.
-10. [Tech Debt 1 - Subtask 3] - [High Impact/High Effort] - Increase test coverage for custom_openai, plugins_manager.
-11. [Gap 4] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-12. [Gap 5] - [Low Impact/Low Effort] - Allow composing System Fragments (`--sf`, `--system-fragment`).
-13. [Gap 7] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-14. [Gap 8] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-15. [Gap 10] - [Low Impact/Low Effort] - Add support for Database Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
-16. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-17. [Gap 12] - [Low Impact/Low Effort] - Support specifying an API key per request (`--key`).
+1. [Gap 3] - [Medium Impact/Low Effort] - Support dynamic Template Parameters (`-p`, `--param`).
+2. [Gap 6] - [Medium Impact/Low Effort] - Add functionality to Continue Conversations (`-c`, `--continue`, `--cid`, `--conversation`) easily from previous prompt sessions.
+3. [Gap 9] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
+4. [Gap 11] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
+5. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
+6. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+7. [Tech Debt 1 - Subtask 1] - [High Impact/High Effort] - Increase test coverage for models_manager, templates_manager, and schemas_manager.
+8. [Tech Debt 1 - Subtask 2] - [High Impact/High Effort] - Increase test coverage for keys_manager, fragments_manager.
+9. [Tech Debt 1 - Subtask 3] - [High Impact/High Effort] - Increase test coverage for custom_openai, plugins_manager.
+10. [Gap 4] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+11. [Gap 5] - [Low Impact/Low Effort] - Allow composing System Fragments (`--sf`, `--system-fragment`).
+12. [Gap 7] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+13. [Gap 8] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+14. [Gap 10] - [Low Impact/Low Effort] - Add support for Database Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
+15. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+16. [Gap 12] - [Low Impact/Low Effort] - Support specifying an API key per request (`--key`).

--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -93,6 +93,21 @@ function M.get_extract_arg()
   return {}
 end
 
+-- Get model options arguments if specified
+function M.get_model_options_args()
+  local model_options = config.get("model_options")
+  if type(model_options) == "table" then
+    local args = {}
+    for key, value in pairs(model_options) do
+      table.insert(args, "-o")
+      table.insert(args, tostring(key))
+      table.insert(args, tostring(value))
+    end
+    return args
+  end
+  return {}
+end
+
 -- Get system fragment arguments if specified
 function M.get_system_fragment_args(fragment_list)
   if not fragment_list or #fragment_list == 0 then
@@ -235,6 +250,7 @@ function M.prompt(prompt, fragment_paths, bufnr)
 
   vim.list_extend(cmd_parts, M.get_tool_args())
   vim.list_extend(cmd_parts, M.get_extract_arg())
+  vim.list_extend(cmd_parts, M.get_model_options_args())
 
   if fragment_paths then
     for _, fragment in ipairs(fragment_paths) do
@@ -287,6 +303,7 @@ function M.prompt_with_current_file(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_system_arg())
   vim.list_extend(cmd_parts, M.get_tool_args())
   vim.list_extend(cmd_parts, M.get_extract_arg())
+  vim.list_extend(cmd_parts, M.get_model_options_args())
 
   -- Add user-specified fragments
   if fragment_paths then
@@ -343,6 +360,7 @@ function M.prompt_with_selection(prompt, fragment_paths, from_visual_mode, bufnr
   vim.list_extend(cmd_parts, M.get_system_arg())
   vim.list_extend(cmd_parts, M.get_tool_args())
   vim.list_extend(cmd_parts, M.get_extract_arg())
+  vim.list_extend(cmd_parts, M.get_model_options_args())
   if fragment_paths then
     vim.list_extend(cmd_parts, M.get_fragment_args(fragment_paths))
   end

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -52,6 +52,11 @@ M.defaults = {
     type = "boolean",
     desc = "Extract content of fenced code blocks"
   },
+  model_options = {
+    default = nil,
+    type = "table",
+    desc = "Key/value options for the model (e.g., {temperature = 0.8, top_p = 0.9})"
+  },
   -- Add more config options here
 }
 

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -49,6 +49,42 @@ describe('llm.commands', function() -- This is a new test suite for llm.commands
     package.loaded['llm.core.utils.ui'] = nil
   end)
 
+  describe('get_model_options_args', function()
+    it('should return empty table if model_options is nil', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'model_options' then return nil end
+        return nil
+      end)
+      local result = commands.get_model_options_args()
+      assert.same({}, result)
+    end)
+
+    it('should return -o arguments if model_options is a table', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'model_options' then return { temperature = 0.8, top_p = 0.9 } end
+        return nil
+      end)
+      local result = commands.get_model_options_args()
+      -- Since pairs order is undefined, we need to check if both are present
+      assert.is_true(#result == 6)
+
+      local has_temp = false
+      local has_topp = false
+      for i = 1, #result, 3 do
+        if result[i] == '-o' then
+          if result[i+1] == 'temperature' and result[i+2] == '0.8' then
+            has_temp = true
+          elseif result[i+1] == 'top_p' and result[i+2] == '0.9' then
+            has_topp = true
+          end
+        end
+      end
+
+      assert.is_true(has_temp)
+      assert.is_true(has_topp)
+    end)
+  end)
+
   describe('get_extract_arg', function()
     it('should return {-x} if extract is true', function()
       package.loaded['llm.config'].get = spy.new(function(key)


### PR DESCRIPTION
This commit introduces the ability to configure model options (such as temperature, top_p, etc.) for `llm-nvim`. It addresses Gap 2 from the ranked backlog by allowing users to define a table of options that get parsed into the corresponding CLI flags. Included are tests to verify the command arguments parsing.

---
*PR created automatically by Jules for task [16554554489707995868](https://jules.google.com/task/16554554489707995868) started by @julwrites*