### PR TITLE
feat: Add support for Template Options

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,7 +21,6 @@
 
 ## Gaps & Tech Debt
 - [Gap 1]: Missing support for Multi-modal attachments (`-a`, `--attachment`, `--at`, `--attachment-type`).
-- [Gap 2]: Missing support for Template Options (`-t`, `--template`).
 - [Gap 3]: Missing support for Template Parameters (`-p`, `--param`).
 - [Gap 4]: Missing support for Usage tracking (`-u`, `--usage`).
 - [Gap 5]: Missing support for Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
@@ -38,8 +37,7 @@
 - [Gap 13]: Missing support for Extract Last (`--xl`, `--extract-last`).
 
 ## Ranked Backlog
-1. [Gap 2] - [Medium Impact/Low Effort] - Add support for Template Options (`-t`, `--template`).
-2. [Gap 3] - [Medium Impact/Low Effort] - Support dynamic Template Parameters (`-p`, `--param`).
+1. [Gap 3] - [Medium Impact/Low Effort] - Support dynamic Template Parameters (`-p`, `--param`).
 3. [Gap 6] - [Medium Impact/Low Effort] - Add functionality to Continue Conversations (`-c`, `--continue`, `--cid`, `--conversation`) easily from previous prompt sessions.
 4. [Gap 9] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
 5. [Gap 11] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).

--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -108,6 +108,15 @@ function M.get_model_options_args()
   return {}
 end
 
+-- Get template argument if specified
+function M.get_template_arg()
+  local template = config.get("template")
+  if template and template ~= "" then
+    return { "-t", template }
+  end
+  return {}
+end
+
 -- Get system fragment arguments if specified
 function M.get_system_fragment_args(fragment_list)
   if not fragment_list or #fragment_list == 0 then
@@ -251,6 +260,7 @@ function M.prompt(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_tool_args())
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
+  vim.list_extend(cmd_parts, M.get_template_arg())
 
   if fragment_paths then
     for _, fragment in ipairs(fragment_paths) do
@@ -304,6 +314,7 @@ function M.prompt_with_current_file(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_tool_args())
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
+  vim.list_extend(cmd_parts, M.get_template_arg())
 
   -- Add user-specified fragments
   if fragment_paths then
@@ -361,6 +372,7 @@ function M.prompt_with_selection(prompt, fragment_paths, from_visual_mode, bufnr
   vim.list_extend(cmd_parts, M.get_tool_args())
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
+  vim.list_extend(cmd_parts, M.get_template_arg())
   if fragment_paths then
     vim.list_extend(cmd_parts, M.get_fragment_args(fragment_paths))
   end

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -57,6 +57,11 @@ M.defaults = {
     type = "table",
     desc = "Key/value options for the model (e.g., {temperature = 0.8, top_p = 0.9})"
   },
+  template = {
+    default = nil,
+    type = "string",
+    desc = "Prompt template to use"
+  },
   -- Add more config options here
 }
 

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -85,6 +85,26 @@ describe('llm.commands', function() -- This is a new test suite for llm.commands
     end)
   end)
 
+  describe('get_template_arg', function()
+    it('should return {-t, template_name} if template is set', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'template' then return 'my-template' end
+        return nil
+      end)
+      local result = commands.get_template_arg()
+      assert.same({ '-t', 'my-template' }, result)
+    end)
+
+    it('should return {} if template is not set', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'template' then return nil end
+        return nil
+      end)
+      local result = commands.get_template_arg()
+      assert.same({}, result)
+    end)
+  end)
+
   describe('get_extract_arg', function()
     it('should return {-x} if extract is true', function()
       package.loaded['llm.config'].get = spy.new(function(key)


### PR DESCRIPTION
This PR implements support for Template Options (`-t`, `--template`) as defined in Gap 2 of the `BACKLOG.md`. 

Changes:
- Configuration: Added `template` field to defaults in `lua/llm/config.lua`.
- Commands: Created `get_template_arg` helper in `lua/llm/commands.lua` and injected it into the prompt building functions to append the `-t` argument.
- Tests: Added comprehensive unit tests for `get_template_arg` in `commands_spec.lua` ensuring correct behavior when the config option is populated versus absent.
- Maintenance: Removed Gap 2 from the backlog, marking it complete. All tests pass locally.

---
*PR created automatically by Jules for task [2644159533550633636](https://jules.google.com/task/2644159533550633636) started by @julwrites*