### PR TITLE
Add Template Parameters (-p) Feature

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,7 +22,6 @@
 
 ## Gaps & Tech Debt
 - [Gap 1]: Missing support for Multi-modal attachments (`-a`, `--attachment`, `--at`, `--attachment-type`).
-- [Gap 2]: Missing support for Template Parameters (`-p`, `--param`).
 - [Gap 3]: Missing support for Usage tracking (`-u`, `--usage`).
 - [Gap 4]: Missing support for Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
 - [Gap 5]: Missing support for Continue Conversation (`-c`, `--continue`, `--cid`, `--conversation`).
@@ -38,8 +37,7 @@
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
 
 ## Ranked Backlog
-1. [Gap 2] - [Medium Impact/Low Effort] - Support dynamic Template Parameters (`-p`, `--param`).
-2. [Gap 5] - [Medium Impact/Low Effort] - Add functionality to Continue Conversations (`-c`, `--continue`, `--cid`, `--conversation`) easily from previous prompt sessions.
+1. [Gap 5] - [Medium Impact/Low Effort] - Add functionality to Continue Conversations (`-c`, `--continue`, `--cid`, `--conversation`) easily from previous prompt sessions.
 3. [Gap 8] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
 4. [Gap 10] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
 5. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).

--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -117,6 +117,21 @@ function M.get_template_arg()
   return {}
 end
 
+-- Get template parameters arguments if specified
+function M.get_template_params_args()
+  local template_params = config.get("template_params")
+  if type(template_params) == "table" then
+    local args = {}
+    for key, value in pairs(template_params) do
+      table.insert(args, "-p")
+      table.insert(args, tostring(key))
+      table.insert(args, tostring(value))
+    end
+    return args
+  end
+  return {}
+end
+
 -- Get system fragment arguments if specified
 function M.get_system_fragment_args(fragment_list)
   if not fragment_list or #fragment_list == 0 then
@@ -261,6 +276,7 @@ function M.prompt(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
+  vim.list_extend(cmd_parts, M.get_template_params_args())
 
   if fragment_paths then
     for _, fragment in ipairs(fragment_paths) do
@@ -315,6 +331,7 @@ function M.prompt_with_current_file(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
+  vim.list_extend(cmd_parts, M.get_template_params_args())
 
   -- Add user-specified fragments
   if fragment_paths then
@@ -373,6 +390,7 @@ function M.prompt_with_selection(prompt, fragment_paths, from_visual_mode, bufnr
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
+  vim.list_extend(cmd_parts, M.get_template_params_args())
   if fragment_paths then
     vim.list_extend(cmd_parts, M.get_fragment_args(fragment_paths))
   end

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -62,6 +62,11 @@ M.defaults = {
     type = "string",
     desc = "Prompt template to use"
   },
+  template_params = {
+    default = nil,
+    type = "table",
+    desc = "Key/value parameters for the template (e.g., {name = 'World'})"
+  },
   -- Add more config options here
 }
 

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -85,6 +85,41 @@ describe('llm.commands', function() -- This is a new test suite for llm.commands
     end)
   end)
 
+  describe('get_template_params_args', function()
+    it('should return empty table if template_params is nil', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'template_params' then return nil end
+        return nil
+      end)
+      local result = commands.get_template_params_args()
+      assert.same({}, result)
+    end)
+
+    it('should return -p arguments if template_params is a table', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'template_params' then return { name = 'World', age = 30 } end
+        return nil
+      end)
+      local result = commands.get_template_params_args()
+      assert.is_true(#result == 6)
+
+      local has_name = false
+      local has_age = false
+      for i = 1, #result, 3 do
+        if result[i] == '-p' then
+          if result[i+1] == 'name' and result[i+2] == 'World' then
+            has_name = true
+          elseif result[i+1] == 'age' and result[i+2] == '30' then
+            has_age = true
+          end
+        end
+      end
+
+      assert.is_true(has_name)
+      assert.is_true(has_age)
+    end)
+  end)
+
   describe('get_template_arg', function()
     it('should return {-t, template_name} if template is set', function()
       package.loaded['llm.config'].get = spy.new(function(key)


### PR DESCRIPTION
Implemented support for dynamic Template Parameters (`-p`, `--param`) based on highest priority item in BACKLOG.md.

Changes:
1. `lua/llm/config.lua`: Added `template_params` table schema.
2. `lua/llm/commands.lua`: Implemented `get_template_params_args()` and included it in the command arguments stream for all prompt variants.
3. `tests/spec/commands_spec.lua`: Added `busted` tests for the new parameter generation.
4. `BACKLOG.md`: Removed `Gap 2`.

---
*PR created automatically by Jules for task [6388159725558964927](https://jules.google.com/task/6388159725558964927) started by @julwrites*