### PR TITLE
docs: Add Embeddings Support to BACKLOG.md

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -18,6 +18,7 @@
 - [Stream Control]: Do not stream output.
 - [Schemas]: Manage stored schemas and use them in prompts.
 - [System Fragment]: Add fragment to system prompt.
+- [Embeddings]: Create embeddings, find similar items, and manage collections.
 
 ## Gaps & Tech Debt
 - [Gap 1]: Missing support for Multi-modal attachments (`-a`, `--attachment`, `--at`, `--attachment-type`).
@@ -35,18 +36,20 @@
 - [Gap 10]: Missing support for Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
 - [Tech Debt 5]: Refactor duplicated command construction logic across `M.prompt`, `M.prompt_with_current_file`, and `M.prompt_with_selection` in `lua/llm/commands.lua`.
 - [Gap 11]: Missing support for System Fragment (`--sf`, `--system-fragment`).
+- [Gap 12]: Missing support for Embeddings commands (`embed`, `similar`, `collections`, etc.).
 
 ## Ranked Backlog
-1. [Gap 7] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
-2. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
-3. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
-4. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
-5. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
-6. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-7. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-8. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-9. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-10. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-11. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-12. [Gap 10] - [Low Impact/Low Effort] - Add support for Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
-13. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+1. [Gap 12] - [High Impact/High Effort] - Add support for Embeddings commands (`embed`, `similar`, `collections`, etc.).
+2. [Gap 7] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
+3. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
+4. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
+5. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
+6. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
+7. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+8. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+9. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+10. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+11. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+12. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+13. [Gap 10] - [Low Impact/Low Effort] - Add support for Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
+14. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).


### PR DESCRIPTION
Audited the upstream `llm` CLI functionality and identified that support for Embeddings (`llm embed`, `llm similar`, `llm collections`) is missing from the `llm-nvim` plugin. 

Updated `BACKLOG.md` to:
1. Add Embeddings to the `Unranked Catalog`.
2. Document the missing functionality as `Gap 12` in the `Gaps & Tech Debt` section.
3. Place the gap as the #1 priority item in the `Ranked Backlog` due to its high impact and high effort, bumping all other priorities down.

---
*PR created automatically by Jules for task [5585801710525663971](https://jules.google.com/task/5585801710525663971) started by @julwrites*