### PR TITLE
Decompose Gap 12 into sub-tasks in BACKLOG.md

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -36,20 +36,24 @@
 - [Gap 10]: Missing support for Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
 - [Tech Debt 5]: Refactor duplicated command construction logic across `M.prompt`, `M.prompt_with_current_file`, and `M.prompt_with_selection` in `lua/llm/commands.lua`.
 - [Gap 11]: Missing support for System Fragment (`--sf`, `--system-fragment`).
-- [Gap 12]: Missing support for Embeddings commands (`embed`, `similar`, `collections`, etc.).
+- [Gap 12.1]: Missing support for Embeddings commands (`embed` and `embed-multi`).
+- [Gap 12.2]: Missing support for Embeddings commands (`similar`).
+- [Gap 12.3]: Missing support for Embeddings commands (`collections` and `aliases`).
 
 ## Ranked Backlog
-1. [Gap 12] - [High Impact/High Effort] - Add support for Embeddings commands (`embed`, `similar`, `collections`, etc.).
-2. [Gap 7] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
-3. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
-4. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
-5. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
-6. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
-7. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-8. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-9. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-10. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-11. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-12. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-13. [Gap 10] - [Low Impact/Low Effort] - Add support for Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
-14. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+1. [Gap 12.1] - [High Impact/Medium Effort] - Add support for Embeddings commands (`embed` and `embed-multi`).
+2. [Gap 12.2] - [High Impact/Medium Effort] - Add support for Embeddings commands (`similar`).
+3. [Gap 12.3] - [High Impact/Medium Effort] - Add support for Embeddings commands (`collections` and `aliases`).
+4. [Gap 7] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
+5. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
+6. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
+7. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
+8. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
+9. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+10. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+11. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+12. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+13. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+14. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+15. [Gap 10] - [Low Impact/Low Effort] - Add support for Logging options (`-d`, `--database`, `-n`, `--no-log`, `--log`).
+16. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).


### PR DESCRIPTION
I have evaluated the #1 ranked item in `BACKLOG.md` (Gap 12: Add support for Embeddings commands). Because this task involves implementing multiple new commands (`embed`, `similar`, `collections`, etc.) and would require modifying several files and potentially architectural shifts, I have decomposed it into 3 smaller sub-tasks (Gap 12.1, 12.2, 12.3) in accordance with the task instructions. I have replaced the original item in the `BACKLOG.md` file while preserving the #1 ranking and re-numbered the subsequent list items. Tests pass successfully.

---
*PR created automatically by Jules for task [3269328296911583531](https://jules.google.com/task/3269328296911583531) started by @julwrites*