### PR TITLE
chore(backlog): decompose Gap 12.1 into sub-tasks

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,26 +33,28 @@
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
 - [Tech Debt 5]: Refactor duplicated command construction logic across `M.prompt`, `M.prompt_with_current_file`, and `M.prompt_with_selection` in `lua/llm/commands.lua`.
 - [Gap 11]: Missing support for System Fragment (`--sf`, `--system-fragment`).
-- [Gap 12.1]: Missing support for Embeddings commands (`embed` and `embed-multi`).
+- [Gap 12.1.1]: Missing support for Embeddings commands (`embed`).
+- [Gap 12.1.2]: Missing support for Embeddings commands (`embed-multi`).
 - [Gap 12.2]: Missing support for Embeddings commands (`similar`).
 - [Gap 12.3]: Missing support for Embeddings commands (`collections` and `aliases`).
 - [Gap 13]: Missing support for API Key override (`--key`).
 
 ## Ranked Backlog
-1. [Gap 12.1] - [High Impact/Medium Effort] - Add support for Embeddings commands (`embed` and `embed-multi`).
-2. [Gap 12.2] - [High Impact/Medium Effort] - Add support for Embeddings commands (`similar`).
-3. [Gap 12.3] - [High Impact/Medium Effort] - Add support for Embeddings commands (`collections` and `aliases`).
-4. [Gap 7] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
-5. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
-6. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
-7. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
-8. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
-9. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
-10. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-11. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-12. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-13. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-14. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-15. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-16. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-17. [Gap 13] - [Low Impact/Low Effort] - Add support for API Key override (`--key`).
+1. [Gap 12.1.1] - [High Impact/Medium Effort] - Add support for Embeddings commands (`embed`).
+2. [Gap 12.1.2] - [High Impact/Medium Effort] - Add support for Embeddings commands (`embed-multi`).
+3. [Gap 12.2] - [High Impact/Medium Effort] - Add support for Embeddings commands (`similar`).
+4. [Gap 12.3] - [High Impact/Medium Effort] - Add support for Embeddings commands (`collections` and `aliases`).
+5. [Gap 7] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
+6. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
+7. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
+8. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
+9. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
+10. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
+11. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+12. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+13. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+14. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+15. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+16. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+17. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+18. [Gap 13] - [Low Impact/Low Effort] - Add support for API Key override (`--key`).


### PR DESCRIPTION
Decomposed Gap 12.1 in BACKLOG.md into two separate sub-tasks (`embed` and `embed-multi`) as the original task was assessed to modify more than 3 files (`lua/llm/commands.lua`, `lua/llm/facade.lua`, `tests/spec/commands_spec.lua`, `tests/spec/facade_spec.lua`). Preserved ranking and updated numbering.

---
*PR created automatically by Jules for task [13329055908318333585](https://jules.google.com/task/13329055908318333585) started by @julwrites*