### PR TITLE
feat: Add schema options support

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -40,19 +40,18 @@
 - [Gap 15]: Missing support for Database Options (`--log`, `--no-log`, `-d`, `--database`).
 
 ## Ranked Backlog
-1. [Gap 7] - [Medium Impact/Low Effort] - Add support for Schema Options (`--schema`, `--schema-multi`) in prompts.
-2. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
-3. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
-4. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
-5. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
-6. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
-7. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-8. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-9. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-10. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-11. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-12. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-13. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-14. [Gap 13] - [Low Impact/Low Effort] - Add support for API Key override (`--key`).
-15. [Gap 14] - [Low Impact/Low Effort] - Add support for Logs commands to explore logged prompts and responses.
-16. [Gap 15] - [Low Impact/Low Effort] - Add support for Database Options (`--log`, `--no-log`, `-d`, `--database`).
+1. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
+2. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
+3. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
+4. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
+5. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
+6. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+7. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+8. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+9. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+10. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+11. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+12. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+13. [Gap 13] - [Low Impact/Low Effort] - Add support for API Key override (`--key`).
+14. [Gap 14] - [Low Impact/Low Effort] - Add support for Logs commands to explore logged prompts and responses.
+15. [Gap 15] - [Low Impact/Low Effort] - Add support for Database Options (`--log`, `--no-log`, `-d`, `--database`).

--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -117,6 +117,18 @@ function M.get_template_arg()
   return {}
 end
 
+-- Get schema arguments if specified
+function M.get_schema_args()
+  local schema = config.get("schema")
+  local schema_multi = config.get("schema_multi")
+  if schema and schema ~= "" then
+    return { "--schema", schema }
+  elseif schema_multi and schema_multi ~= "" then
+    return { "--schema-multi", schema_multi }
+  end
+  return {}
+end
+
 -- Get template parameters arguments if specified
 function M.get_template_params_args()
   local template_params = config.get("template_params")
@@ -273,6 +285,7 @@ function M.prompt(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
   vim.list_extend(cmd_parts, M.get_template_params_args())
+  vim.list_extend(cmd_parts, M.get_schema_args())
   vim.list_extend(cmd_parts, M.get_conversation_args())
 
   if fragment_paths then
@@ -329,6 +342,7 @@ function M.prompt_with_current_file(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
   vim.list_extend(cmd_parts, M.get_template_params_args())
+  vim.list_extend(cmd_parts, M.get_schema_args())
   vim.list_extend(cmd_parts, M.get_conversation_args())
 
   -- Add user-specified fragments
@@ -389,6 +403,7 @@ function M.prompt_with_selection(prompt, fragment_paths, from_visual_mode, bufnr
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
   vim.list_extend(cmd_parts, M.get_template_params_args())
+  vim.list_extend(cmd_parts, M.get_schema_args())
   vim.list_extend(cmd_parts, M.get_conversation_args())
   if fragment_paths then
     vim.list_extend(cmd_parts, M.get_fragment_args(fragment_paths))

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -67,6 +67,16 @@ M.defaults = {
     type = "table",
     desc = "Key/value parameters for the template (e.g., {name = 'World'})"
   },
+  schema = {
+    default = nil,
+    type = "string",
+    desc = "Schema option to validate output against"
+  },
+  schema_multi = {
+    default = nil,
+    type = "string",
+    desc = "Schema multi option to validate array output against"
+  },
   continue_conversation = {
     default = false,
     type = "boolean",

--- a/plugin/llm.lua
+++ b/plugin/llm.lua
@@ -46,6 +46,8 @@ if vim.g.llm_auto_update_interval_days then user_config.auto_update_interval_day
 if vim.g.llm_executable_path then user_config.llm_executable_path = vim.g.llm_executable_path end
 if vim.g.llm_tools then user_config.tools = vim.g.llm_tools end
 if vim.g.llm_extract ~= nil then user_config.extract = vim.g.llm_extract end
+if vim.g.llm_schema then user_config.schema = vim.g.llm_schema end
+if vim.g.llm_schema_multi then user_config.schema_multi = vim.g.llm_schema_multi end
 
 llm.setup(user_config)
 

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -140,6 +140,34 @@ describe('llm.commands', function() -- This is a new test suite for llm.commands
     end)
   end)
 
+  describe('get_schema_args', function()
+    it('should return {--schema, schema} if schema is set', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'schema' then return 'test-schema' end
+        return nil
+      end)
+      local result = commands.get_schema_args()
+      assert.same({ '--schema', 'test-schema' }, result)
+    end)
+
+    it('should return {--schema-multi, schema_multi} if schema_multi is set', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'schema_multi' then return 'test-schema-multi' end
+        return nil
+      end)
+      local result = commands.get_schema_args()
+      assert.same({ '--schema-multi', 'test-schema-multi' }, result)
+    end)
+
+    it('should return {} if neither are set', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        return nil
+      end)
+      local result = commands.get_schema_args()
+      assert.same({}, result)
+    end)
+  end)
+
   describe('get_extract_arg', function()
     it('should return {-x} if extract is true', function()
       package.loaded['llm.config'].get = spy.new(function(key)


### PR DESCRIPTION
This commit adds support for Schema Options (`--schema` and `--schema-multi`) when generating prompts via the plugin, which was the #1 ranked item in `BACKLOG.md`.

*   Added `schema` and `schema_multi` to configuration defaults in `lua/llm/config.lua`.
*   Added global variable compatibility logic in `plugin/llm.lua`.
*   Implemented `M.get_schema_args()` in `lua/llm/commands.lua` and updated the prompt generation commands to include them.
*   Added corresponding tests in `tests/spec/commands_spec.lua`.
*   Removed the task from `BACKLOG.md` and renumbered the list.

---
*PR created automatically by Jules for task [14020599044242783898](https://jules.google.com/task/14020599044242783898) started by @julwrites*