### PR TITLE
Add support to Save as Template

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -28,7 +28,6 @@
 - [Gap 5]: Missing support for Query Selection (`-q`, `--query`).
 - [Gap 6]: Missing support for Stream Control (`--no-stream`) and Async Execution (`--async`).
 - [Gap 7]: Missing support for Schema Options (`--schema`, `--schema-multi`) in prompting.
-- [Gap 8]: Missing support for Save as Template (`--save`).
 - [Gap 9]: Missing support for Extract Last (`--xl`, `--extract-last`).
 - [Tech Debt 1]: Increase overall code coverage. Test coverage is currently well below the 80% target.
 - [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
@@ -40,18 +39,17 @@
 - [Gap 15]: Missing support for Database Options (`--log`, `--no-log`, `-d`, `--database`).
 
 ## Ranked Backlog
-1. [Gap 8] - [Medium Impact/Low Effort] - Add support to Save as Template (`--save`).
-2. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
-3. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
-4. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
-5. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
-6. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-7. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-8. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-9. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-10. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-11. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-12. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-13. [Gap 13] - [Low Impact/Low Effort] - Add support for API Key override (`--key`).
-14. [Gap 14] - [Low Impact/Low Effort] - Add support for Logs commands to explore logged prompts and responses.
-15. [Gap 15] - [Low Impact/Low Effort] - Add support for Database Options (`--log`, `--no-log`, `-d`, `--database`).
+1. [Tech Debt 5] - [Medium Impact/Medium Effort] - Refactor duplicated command construction logic in `lua/llm/commands.lua`.
+2. [Gap 1] - [Medium Impact/Medium Effort] - Implement Multi-modal attachment support for models that accept images or other data types (`-a`, `--attachment`, `--at`, `--attachment-type`).
+3. [Gap 3] - [Medium Impact/Medium Effort] - Implement Extended Tool Options (`--functions`, `--td`, `--ta`, `--cl`).
+4. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
+5. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+6. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+7. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+8. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+9. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+10. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+11. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+12. [Gap 13] - [Low Impact/Low Effort] - Add support for API Key override (`--key`).
+13. [Gap 14] - [Low Impact/Low Effort] - Add support for Logs commands to explore logged prompts and responses.
+14. [Gap 15] - [Low Impact/Low Effort] - Add support for Database Options (`--log`, `--no-log`, `-d`, `--database`).

--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -93,6 +93,15 @@ function M.get_extract_arg()
   return {}
 end
 
+-- Get save template argument if specified
+function M.get_save_template_arg()
+  local save = config.get("save")
+  if save and save ~= "" then
+    return { "--save", save }
+  end
+  return {}
+end
+
 -- Get model options arguments if specified
 function M.get_model_options_args()
   local model_options = config.get("model_options")
@@ -284,6 +293,7 @@ function M.prompt(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
+  vim.list_extend(cmd_parts, M.get_save_template_arg())
   vim.list_extend(cmd_parts, M.get_template_params_args())
   vim.list_extend(cmd_parts, M.get_schema_args())
   vim.list_extend(cmd_parts, M.get_conversation_args())
@@ -341,6 +351,7 @@ function M.prompt_with_current_file(prompt, fragment_paths, bufnr)
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
+  vim.list_extend(cmd_parts, M.get_save_template_arg())
   vim.list_extend(cmd_parts, M.get_template_params_args())
   vim.list_extend(cmd_parts, M.get_schema_args())
   vim.list_extend(cmd_parts, M.get_conversation_args())
@@ -402,6 +413,7 @@ function M.prompt_with_selection(prompt, fragment_paths, from_visual_mode, bufnr
   vim.list_extend(cmd_parts, M.get_extract_arg())
   vim.list_extend(cmd_parts, M.get_model_options_args())
   vim.list_extend(cmd_parts, M.get_template_arg())
+  vim.list_extend(cmd_parts, M.get_save_template_arg())
   vim.list_extend(cmd_parts, M.get_template_params_args())
   vim.list_extend(cmd_parts, M.get_schema_args())
   vim.list_extend(cmd_parts, M.get_conversation_args())

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -62,6 +62,11 @@ M.defaults = {
     type = "string",
     desc = "Prompt template to use"
   },
+  save = {
+    default = nil,
+    type = "string",
+    desc = "Save prompt as a template with this name"
+  },
   template_params = {
     default = nil,
     type = "table",

--- a/plugin/llm.lua
+++ b/plugin/llm.lua
@@ -48,6 +48,7 @@ if vim.g.llm_tools then user_config.tools = vim.g.llm_tools end
 if vim.g.llm_extract ~= nil then user_config.extract = vim.g.llm_extract end
 if vim.g.llm_schema then user_config.schema = vim.g.llm_schema end
 if vim.g.llm_schema_multi then user_config.schema_multi = vim.g.llm_schema_multi end
+if vim.g.llm_save then user_config.save = vim.g.llm_save end
 
 llm.setup(user_config)
 

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -140,6 +140,26 @@ describe('llm.commands', function() -- This is a new test suite for llm.commands
     end)
   end)
 
+  describe('get_save_template_arg', function()
+    it('should return {--save, template_name} if save is set', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'save' then return 'my-template' end
+        return nil
+      end)
+      local result = commands.get_save_template_arg()
+      assert.same({ '--save', 'my-template' }, result)
+    end)
+
+    it('should return {} if save is not set', function()
+      package.loaded['llm.config'].get = spy.new(function(key)
+        if key == 'save' then return nil end
+        return nil
+      end)
+      local result = commands.get_save_template_arg()
+      assert.same({}, result)
+    end)
+  end)
+
   describe('get_schema_args', function()
     it('should return {--schema, schema} if schema is set', function()
       package.loaded['llm.config'].get = spy.new(function(key)


### PR DESCRIPTION
Implemented support for the `--save` CLI option when executing prompts to save them as templates. This addresses `[Gap 8]` from the backlog.

---
*PR created automatically by Jules for task [10000914890864855460](https://jules.google.com/task/10000914890864855460) started by @julwrites*