### PR TITLE
Fix urllib request hang vulnerability in scripts/llm.py

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -28,7 +28,6 @@
 
 ## Gaps & Tech Debt
 - [Bug 1]: Missing carriage return (`\r`) handling when splitting buffer on newlines in `job.lua`.
-- [Bug 2]: Missing timeouts on `urllib.request.urlopen` calls in `scripts/llm.py` which can hang indefinitely.
 - [Gap 2]: Missing support for Usage tracking (`-u`, `--usage`).
 - [Gap 5]: Missing support for Query Selection (`-q`, `--query`).
 - [Gap 6]: Missing support for Stream Control (`--no-stream`) and Async Execution (`--async`).
@@ -47,21 +46,20 @@
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
 
 ## Ranked Backlog
-1. [Bug 2] - [High Impact/Low Effort] - Add timeouts to `urllib.request.urlopen` calls in `scripts/llm.py` to prevent hanging.
-2. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
-3. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
-4. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-5. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-6. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-7. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-8. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-9. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-10. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-11. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-12. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-13. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-14. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-15. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-16. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
-17. [Gap 21] - [Low Impact/Low Effort] - Add support for Database path (`-d`, `--database`).
-18. [Gap 22] - [Low Impact/Low Effort] - Add support for No Log (`-n`, `--no-log`) and Log (`--log`).
+1. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
+2. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
+3. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+4. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+5. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+6. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+7. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+8. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+9. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+10. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+11. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+12. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
+13. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
+14. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+15. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
+16. [Gap 21] - [Low Impact/Low Effort] - Add support for Database path (`-d`, `--database`).
+17. [Gap 22] - [Low Impact/Low Effort] - Add support for No Log (`-n`, `--no-log`) and Log (`--log`).

--- a/scripts/llm.py
+++ b/scripts/llm.py
@@ -34,7 +34,7 @@ def call_anthropic(prompt, system=None, model="claude-3-5-sonnet-20240620", api_
     req = urllib.request.Request(url, json.dumps(data).encode("utf-8"), headers)
 
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=60) as response:
             result = json.loads(response.read().decode("utf-8"))
             return result["content"][0]["text"]
     except urllib.error.HTTPError as e:
@@ -66,7 +66,7 @@ def call_openai(prompt, system=None, model="gpt-4o", api_key=None):
     req = urllib.request.Request(url, json.dumps(data).encode("utf-8"), headers)
 
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=60) as response:
             result = json.loads(response.read().decode("utf-8"))
             return result["choices"][0]["message"]["content"]
     except urllib.error.HTTPError as e:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+from scripts import llm
+
+class TestLLM(unittest.TestCase):
+    @patch('scripts.llm.urllib.request.urlopen')
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
+    def test_call_anthropic_timeout(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"content": [{"text": "response"}]}'
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        llm.call_anthropic("hello")
+
+        mock_urlopen.assert_called_once()
+        _, kwargs = mock_urlopen.call_args
+        self.assertEqual(kwargs.get('timeout'), 60)
+
+    @patch('scripts.llm.urllib.request.urlopen')
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_call_openai_timeout(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"choices": [{"message": {"content": "response"}}]}'
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        llm.call_openai("hello")
+
+        mock_urlopen.assert_called_once()
+        _, kwargs = mock_urlopen.call_args
+        self.assertEqual(kwargs.get('timeout'), 60)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR addresses Bug 2 from the backlog by adding timeouts to `urllib.request.urlopen` calls in the Anthropic and OpenAI adapter functions inside `scripts/llm.py`. A timeout of 60 seconds is explicitly set to prevent indefinite hanging in the case of network issues. Unit tests using `unittest.mock` were also added to verify the timeout configuration. The `BACKLOG.md` was appropriately updated.

---
*PR created automatically by Jules for task [15639681927882183336](https://jules.google.com/task/15639681927882183336) started by @julwrites*