### PR TITLE
Audit BACKLOG.md and scripts/llm.py

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,8 +23,6 @@
 - [Collections]: View and manage collections of embeddings (`llm collections`).
 - [Similar]: Return top N similar IDs from a collection using cosine similarity (`llm similar`).
 - [Attachments]: Multi-modal models can be called with attachments (`-a`, `--at`).
-- [Logs]: Tools for exploring logged prompts and responses (`llm logs`, `-d`, `-n`, `--log`).
-- [Keys]: Manage stored API keys for different models (`llm keys`).
 
 ## Gaps & Tech Debt
 - [Bug 1]: Missing carriage return (`\r`) handling when splitting buffer on newlines in `job.lua`.
@@ -38,9 +36,8 @@
 - [Gap 18]: Missing support for Similarity search (`llm similar`).
 - [Gap 19]: Missing support for explicit Attachment Type (`--at`, `--attachment-type`).
 - [Gap 20]: Missing support for embed-multi (`llm embed-multi`).
-- [Gap 21]: Missing support for Database path (`-d`, `--database`).
-- [Gap 22]: Missing support for No Log (`-n`, `--no-log`) and Log (`--log`).
 - [Gap 23]: Missing support for Model Aliases (`llm aliases`).
+- [Bug 2]: Missing URLError exception handling in scripts/llm.py.
 - [Tech Debt 1]: Increase overall code coverage. Test coverage is currently well below the 80% target.
 - [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
@@ -48,18 +45,17 @@
 ## Ranked Backlog
 1. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
 2. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
-3. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-4. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-5. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-6. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-7. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-8. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-9. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-10. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-11. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-12. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-13. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-14. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-15. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
-16. [Gap 21] - [Low Impact/Low Effort] - Add support for Database path (`-d`, `--database`).
-17. [Gap 22] - [Low Impact/Low Effort] - Add support for No Log (`-n`, `--no-log`) and Log (`--log`).
+3. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
+4. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+5. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+6. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+7. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+8. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+9. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+10. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+11. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+12. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+13. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
+14. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
+15. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+16. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).


### PR DESCRIPTION
Audited the upstream CLI documentation to filter out non-editor-relevant features. Documented an identified bug in `scripts/llm.py` where a `urllib.error.URLError` exception is not being caught, potentially causing a stack trace output. Cleaned up the `BACKLOG.md` list formatting to re-number and sort correctly after additions and subtractions.

---
*PR created automatically by Jules for task [2821500069668706424](https://jules.google.com/task/2821500069668706424) started by @julwrites*