### PR TITLE
Decompose Tech Debt 1 into multiple subtasks

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -38,24 +38,32 @@
 - [Gap 20]: Missing support for embed-multi (`llm embed-multi`).
 - [Gap 23]: Missing support for Model Aliases (`llm aliases`).
 - [Bug 2]: Missing URLError exception handling in scripts/llm.py.
-- [Tech Debt 1]: Increase overall code coverage. Test coverage is currently well below the 80% target.
+- [Tech Debt 1.1]: Increase test coverage for templates_manager.lua to >80%.
+- [Tech Debt 1.2]: Increase test coverage for schemas_manager.lua to >80%.
+- [Tech Debt 1.3]: Increase test coverage for models_manager.lua to >80%.
+- [Tech Debt 1.4]: Increase test coverage for unified_manager.lua to >80%.
+- [Tech Debt 1.5]: Increase test coverage for plugins_manager.lua to >80%.
 - [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
 
 ## Ranked Backlog
-1. [Tech Debt 1] - [Medium Impact/Medium Effort] - Increase overall code coverage. Test coverage is currently well below the 80% target.
-2. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
-3. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
-4. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-5. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-6. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-7. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-8. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-9. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-10. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-11. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-12. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-13. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-14. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-15. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-16. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
+1. [Tech Debt 1.1] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
+2. [Tech Debt 1.2] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+3. [Tech Debt 1.3] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+4. [Tech Debt 1.4] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+5. [Tech Debt 1.5] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+6. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
+7. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
+8. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+9. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+10. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+11. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+12. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+13. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+14. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+15. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+16. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+17. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
+18. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
+19. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+20. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).


### PR DESCRIPTION
The #1 task in the backlog was `[Tech Debt 1]: Increase overall code coverage`. Upon inspection of the `luacov.report.out` coverage report, I found that coverage was low across several files (including managers and UI views). Since improving coverage would require modifying many files, I followed the condition: "If the task requires more than 3 file modifications or significant architectural shifts, break it down into 2-5 smaller, sequential sub-tasks. Replace the original item in BACKLOG.md with these sub-tasks, preserving their #1 ranking. Halt execution." 

I decomposed it into 5 sub-tasks targeting specific managers and successfully replaced the entries in both the `Gaps & Tech Debt` and `Ranked Backlog` sections of `BACKLOG.md`. The rest of the backlog was correctly renumbered, and all unit tests continued to pass without regressions.

---
*PR created automatically by Jules for task [16299909724014722901](https://jules.google.com/task/16299909724014722901) started by @julwrites*