### PR TITLE
docs: Update BACKLOG.md with jobstart bug discovery

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -50,28 +50,30 @@
 - [Bug 3]: Unhandled empty string return from `write_context_to_temp_file` in `M.prompt_with_selection` leads to invalid command arguments.
 - [Gap 24]: Missing support for API Key management (`llm keys`, `--key`).
 - [Bug 4]: Missing `os.getenv` handling for API keys in `scripts/llm.py` could fail silently if `urllib` isn't properly mocked.
+- [Bug 5]: Neovim's `vim.fn.jobstart` behaves asynchronously, but `tests/spec/api_spec.lua` misses validation on output stream timing and truncation issues during `job.lua` data accumulation.
 
 ## Ranked Backlog
-1. [Tech Debt 1.2] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-2. [Tech Debt 1.3] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-3. [Tech Debt 1.4] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-4. [Tech Debt 1.5] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-5. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
-6. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
-7. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
-8. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-9. [Bug 3] - [Medium Impact/Low Effort] - Handle empty string return from `write_context_to_temp_file` in `commands.lua`.
-10. [Tech Debt 4] - [Low Impact/Medium Effort] - Replace `os.tmpname()` with secure temporary file creation and reliable cleanup in `commands.lua`.
-11. [Gap 24] - [Low Impact/Low Effort] - Add support for explicit API Keys (`--key`) and keys management (`llm keys`).
-12. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-13. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-14. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-15. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-16. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-17. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-18. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-19. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-20. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-21. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-22. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-23. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
+1. [Bug 5] - [High Impact/Low Effort] - Neovim's `vim.fn.jobstart` behaves asynchronously, but `tests/spec/api_spec.lua` misses validation on output stream timing and truncation issues during `job.lua` data accumulation.
+2. [Tech Debt 1.2] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+3. [Tech Debt 1.3] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+4. [Tech Debt 1.4] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+5. [Tech Debt 1.5] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+6. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
+7. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
+8. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
+9. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+10. [Bug 3] - [Medium Impact/Low Effort] - Handle empty string return from `write_context_to_temp_file` in `commands.lua`.
+11. [Tech Debt 4] - [Low Impact/Medium Effort] - Replace `os.tmpname()` with secure temporary file creation and reliable cleanup in `commands.lua`.
+12. [Gap 24] - [Low Impact/Low Effort] - Add support for explicit API Keys (`--key`) and keys management (`llm keys`).
+13. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+14. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+15. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+16. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+17. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+18. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+19. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+20. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+21. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
+22. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
+23. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+24. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).


### PR DESCRIPTION
Audited the codebase and found a new issue where `job.lua` misses lines because Neovim's `vim.fn.jobstart` output (`on_stdout`) is delivered already split by newlines (each chunk is a separate table entry without the `\n` character). I have added this finding as `Bug 5` to the `BACKLOG.md` under Gaps & Tech Debt and ranked it at the top of the Ranked Backlog (High Impact/Low Effort). Note that no other upstream gaps were identified during this audit.

---
*PR created automatically by Jules for task [10195194036770163303](https://jules.google.com/task/10195194036770163303) started by @julwrites*