### PR TITLE
Fix job output chunking and truncation issue

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -50,34 +50,32 @@
 - [Bug 3]: Unhandled empty string return from `write_context_to_temp_file` in `M.prompt_with_selection` leads to invalid command arguments.
 - [Gap 24]: Missing support for API Key management (`llm keys`, `--key`).
 - [Bug 4]: Missing `os.getenv` handling for API keys in `scripts/llm.py` could fail silently if `urllib` isn't properly mocked.
-- [Bug 5]: Neovim's `vim.fn.jobstart` behaves asynchronously, but `tests/spec/api_spec.lua` misses validation on output stream timing and truncation issues during `job.lua` data accumulation.
 - [Bug 6]: Premature deletion of temporary files used for visual selection in `lua/llm/commands.lua` before the asynchronous command completes.
 - [Tech Debt 1.6]: Increase test coverage for tools_manager.lua to >80%.
 
 ## Ranked Backlog
-1. [Bug 5] - [High Impact/Low Effort] - Neovim's `vim.fn.jobstart` behaves asynchronously, but `tests/spec/api_spec.lua` misses validation on output stream timing and truncation issues during `job.lua` data accumulation.
-2. [Bug 6] - [High Impact/Low Effort] - Fix premature temporary file deletion in `commands.lua` when using visual selection.
-3. [Tech Debt 1.2] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-4. [Tech Debt 1.3] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-5. [Tech Debt 1.4] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-6. [Tech Debt 1.5] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-7. [Tech Debt 1.6] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
-8. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
-9. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
-10. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
-11. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-12. [Bug 3] - [Medium Impact/Low Effort] - Handle empty string return from `write_context_to_temp_file` in `commands.lua`.
-13. [Tech Debt 4] - [Low Impact/Medium Effort] - Replace `os.tmpname()` with secure temporary file creation and reliable cleanup in `commands.lua`.
-14. [Gap 24] - [Low Impact/Low Effort] - Add support for explicit API Keys (`--key`) and keys management (`llm keys`).
-15. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-16. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-17. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-18. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-19. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-20. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-21. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-22. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-23. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-24. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-25. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-26. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
+1. [Bug 6] - [High Impact/Low Effort] - Fix premature temporary file deletion in `commands.lua` when using visual selection.
+2. [Tech Debt 1.2] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+3. [Tech Debt 1.3] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+4. [Tech Debt 1.4] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+5. [Tech Debt 1.5] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+6. [Tech Debt 1.6] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
+7. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
+8. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
+9. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
+10. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+11. [Bug 3] - [Medium Impact/Low Effort] - Handle empty string return from `write_context_to_temp_file` in `commands.lua`.
+12. [Tech Debt 4] - [Low Impact/Medium Effort] - Replace `os.tmpname()` with secure temporary file creation and reliable cleanup in `commands.lua`.
+13. [Gap 24] - [Low Impact/Low Effort] - Add support for explicit API Keys (`--key`) and keys management (`llm keys`).
+14. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+15. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+16. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+17. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+18. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+19. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+20. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+21. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+22. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
+23. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
+24. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+25. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).

--- a/lua/llm/core/utils/job.lua
+++ b/lua/llm/core/utils/job.lua
@@ -29,25 +29,24 @@ function M.run(cmd, callbacks)
 
     local buffer = (event == "stdout") and stdout_buffer or stderr_buffer
 
-    for _, chunk in ipairs(data) do
-      -- Accumulate chunk into buffer
+    for i, chunk in ipairs(data) do
       buffer = buffer .. chunk
 
-      -- Split buffer on newlines
+      if i < #data then
+        buffer = buffer .. "\n"
+      end
+
       local lines = {}
       while true do
         local newline_pos = buffer:find('\n')
         if not newline_pos then break end
 
-        -- Extract line without the newline
         local line = buffer:sub(1, newline_pos - 1)
         table.insert(lines, line)
 
-        -- Remove processed line from buffer
         buffer = buffer:sub(newline_pos + 1)
       end
 
-      -- Update the appropriate buffer
       if event == "stdout" then
         stdout_buffer = buffer
       else

--- a/tests/spec/api_spec.lua
+++ b/tests/spec/api_spec.lua
@@ -69,4 +69,38 @@ describe("api", function()
       assert.spy(jobsend_spy).was.not_called()
     end)
   end)
+
+  describe("job chunking and accumulation", function()
+    local real_job
+
+    before_each(function()
+      package.loaded["llm.core.utils.job"] = nil
+      real_job = require("llm.core.utils.job")
+
+      _G.vim.fn.jobstart = function(cmd, opts)
+        _G._sim_job_opts = opts
+        return 1
+      end
+    end)
+
+    it("handles Neovim data arrays and split lines without truncation", function()
+      local stdout_lines = {}
+      real_job.run({"dummy"}, {
+        on_stdout = function(err, lines)
+          for _, line in ipairs(lines) do
+            table.insert(stdout_lines, line)
+          end
+        end
+      })
+
+      -- Neovim passes split lines. If the final chunk has no newline,
+      -- the last element is that partial line. If it has a newline,
+      -- the last element is an empty string.
+      _G._sim_job_opts.on_stdout(1, {"line1", "line2", "part"})
+      _G._sim_job_opts.on_stdout(1, {"ial", "line3", ""})
+      _G._sim_job_opts.on_exit(1, 0)
+
+      assert.are.same({"line1", "line2", "partial", "line3"}, stdout_lines)
+    end)
+  end)
 end)


### PR DESCRIPTION
Fixes Bug 5 where long streaming outputs from the LLM were occasionally dropping characters or mis-stitching lines due to improper handling of Neovim's `jobstart` line-splitting array format. Wrote targeted busted specs simulating arbitrary chunk boundaries to verify output fidelity.

---
*PR created automatically by Jules for task [17673968388245417652](https://jules.google.com/task/17673968388245417652) started by @julwrites*