### PR TITLE
Fix premature temporary file deletion for visual selections

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -50,32 +50,30 @@
 - [Bug 3]: Unhandled empty string return from `write_context_to_temp_file` in `M.prompt_with_selection` leads to invalid command arguments.
 - [Gap 24]: Missing support for API Key management (`llm keys`, `--key`).
 - [Bug 4]: Missing `os.getenv` handling for API keys in `scripts/llm.py` could fail silently if `urllib` isn't properly mocked.
-- [Bug 6]: Premature deletion of temporary files used for visual selection in `lua/llm/commands.lua` before the asynchronous command completes.
 - [Tech Debt 1.6]: Increase test coverage for tools_manager.lua to >80%.
 
 ## Ranked Backlog
-1. [Bug 6] - [High Impact/Low Effort] - Fix premature temporary file deletion in `commands.lua` when using visual selection.
-2. [Tech Debt 1.2] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-3. [Tech Debt 1.3] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-4. [Tech Debt 1.4] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-5. [Tech Debt 1.5] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-6. [Tech Debt 1.6] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
-7. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
-8. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
-9. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
-10. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-11. [Bug 3] - [Medium Impact/Low Effort] - Handle empty string return from `write_context_to_temp_file` in `commands.lua`.
-12. [Tech Debt 4] - [Low Impact/Medium Effort] - Replace `os.tmpname()` with secure temporary file creation and reliable cleanup in `commands.lua`.
-13. [Gap 24] - [Low Impact/Low Effort] - Add support for explicit API Keys (`--key`) and keys management (`llm keys`).
-14. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-15. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-16. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-17. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-18. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-19. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-20. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-21. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-22. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-23. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-24. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-25. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
+1. [Tech Debt 1.2] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+2. [Tech Debt 1.3] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+3. [Tech Debt 1.4] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+4. [Tech Debt 1.5] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+5. [Tech Debt 1.6] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
+6. [Bug 1] - [Medium Impact/Low Effort] - Handle carriage returns (`\r\n`) when splitting buffers in `job.lua`.
+7. [Bug 2] - [Medium Impact/Low Effort] - Missing URLError exception handling in scripts/llm.py.
+8. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
+9. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+10. [Bug 3] - [Medium Impact/Low Effort] - Handle empty string return from `write_context_to_temp_file` in `commands.lua`.
+11. [Tech Debt 4] - [Low Impact/Medium Effort] - Replace `os.tmpname()` with secure temporary file creation and reliable cleanup in `commands.lua`.
+12. [Gap 24] - [Low Impact/Low Effort] - Add support for explicit API Keys (`--key`) and keys management (`llm keys`).
+13. [Gap 23] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+14. [Gap 2] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+15. [Gap 5] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+16. [Gap 6] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+17. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+18. [Gap 9] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+19. [Gap 11] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+20. [Gap 16] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+21. [Gap 17] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
+22. [Gap 18] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
+23. [Gap 19] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+24. [Gap 20] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).

--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -377,9 +377,9 @@ function M.dispatch_command(subcmd, ...)
 end
 
 -- Send a prompt to llm
-function M.prompt(prompt, fragment_paths, bufnr)
+function M.prompt(prompt, fragment_paths, bufnr, on_exit)
   local cmd_parts = M.build_base_cmd(fragment_paths)
-  local _, callbacks = M.prepare_response_buffer_and_callbacks(bufnr)
+  local _, callbacks = M.prepare_response_buffer_and_callbacks(bufnr, on_exit)
   api.run_streaming_command(cmd_parts, prompt, callbacks)
 end
 
@@ -547,13 +547,14 @@ function M.interactive_prompt_with_fragments(opts)
           -- and call M.prompt_with_selection directly with the text, but this adds complexity.
           -- For now, using the temp file path in M.prompt is simpler.
 
-          M.prompt(input_prompt, fragments_list)
-
-          -- Clean up temp file *after* the command runs (or is supposed to run)
-          -- Using defer_fn to ensure it runs after the current execution context
+          local on_exit = nil
           if visual_selection_temp_file then
-            vim.defer_fn(function() os.remove(visual_selection_temp_file) end, 100)
+            on_exit = function()
+              os.remove(visual_selection_temp_file)
+            end
           end
+
+          M.prompt(input_prompt, fragments_list, nil, on_exit)
         end)
       else
         add_more_fragments() -- Should not happen, but ensures loop continues

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -313,6 +313,18 @@ describe('llm.commands', function() -- This is a new test suite for llm.commands
       assert.are.equal('test prompt', call_args[2])
     end)
 
+    it('should handle on_exit callback', function()
+      local on_exit_spy = spy.new(function() end)
+      commands.prompt('test prompt', {}, 1, on_exit_spy)
+
+      assert.spy(api_mock.run_streaming_command).was.called()
+      local call_args = api_mock.run_streaming_command.calls[1]
+      local callbacks = call_args[3]
+
+      callbacks.on_exit()
+      assert.spy(on_exit_spy).was.called()
+    end)
+
     it('should append data to the buffer on stdout', function()
       commands.prompt('test prompt', {}, 1)
 


### PR DESCRIPTION
Fixes Bug 6 where temporary files used for visual selection were deleted prematurely using `vim.defer_fn`, before the asynchronous LLM process was able to read them. This updates `M.interactive_prompt_with_fragments` to pass an `on_exit` cleanup callback to `M.prompt`.

Also removed `[Bug 6]` from the ranked backlog and gaps list as per the objective.

---
*PR created automatically by Jules for task [12675402971375438562](https://jules.google.com/task/12675402971375438562) started by @julwrites*