### PR TITLE
Fix empty string handling in temp file creation and improve temp file security

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,12 +26,10 @@
 
 ## Gaps & Tech Debt
 - [Bug 2]: Missing `urllib.error.URLError` exception handling in `scripts/llm.py` for connection errors.
-- [Bug 3]: Unhandled empty string return from `write_context_to_temp_file` in `commands.lua` leads to invalid command arguments.
 - [Bug 4]: Missing `os.getenv` handling for API keys in `scripts/llm.py` could fail silently if `urllib` isn't properly mocked.
 - [Tech Debt 1]: Hardcoded 60s timeout in `scripts/llm.py` could cause long-running generation to fail.
 - [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
-- [Tech Debt 4]: Replace `os.tmpname()` with secure temporary file creation and reliable cleanup in `commands.lua`.
 - [Tech Debt 5]: Increase test coverage for templates_manager.lua to >80%.
 - [Tech Debt 6]: Increase test coverage for schemas_manager.lua to >80%.
 - [Tech Debt 7]: Increase test coverage for models_manager.lua to >80%.
@@ -54,30 +52,28 @@
 - [Gap 13]: Missing support for Embeddings ('llm embed').
 
 ## Ranked Backlog
-1. [Bug 3] - [High Impact/Low Effort] - Handle empty string return from `write_context_to_temp_file` in `commands.lua`.
-2. [Bug 2] - [Medium Impact/Low Effort] - Missing `urllib.error.URLError` exception handling in `scripts/llm.py` for connection errors.
-3. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
-4. [Gap 12] - [Medium Impact/Medium Effort] - Implement SSE streaming support in `scripts/llm.py` instead of waiting for full response.
-5. [Bug 5] - [Medium Impact/Low Effort] - Handle json.JSONDecodeError in scripts/llm.py.
-6. [Gap 13] - [Medium Impact/Low Effort] - Add support for Embeddings (`llm embed`).
-7. [Tech Debt 1] - [Medium Impact/Low Effort] - Remove hardcoded 60s timeout in `scripts/llm.py` or make it configurable.
-8. [Tech Debt 4] - [Medium Impact/Low Effort] - Replace `os.tmpname()` with secure temporary file creation in `commands.lua`.
-9. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-10. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-11. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-12. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-13. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-14. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
-15. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
-16. [Gap 11] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-17. [Gap 1] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-18. [Gap 2] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-19. [Gap 3] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-20. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-21. [Gap 4] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-22. [Gap 5] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-23. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-24. [Gap 7] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-25. [Gap 8] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-26. [Gap 9] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-27. [Gap 10] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
+1. [Bug 2] - [Medium Impact/Low Effort] - Missing `urllib.error.URLError` exception handling in `scripts/llm.py` for connection errors.
+2. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
+3. [Gap 12] - [Medium Impact/Medium Effort] - Implement SSE streaming support in `scripts/llm.py` instead of waiting for full response.
+4. [Bug 5] - [Medium Impact/Low Effort] - Handle json.JSONDecodeError in scripts/llm.py.
+5. [Gap 13] - [Medium Impact/Low Effort] - Add support for Embeddings (`llm embed`).
+6. [Tech Debt 1] - [Medium Impact/Low Effort] - Remove hardcoded 60s timeout in `scripts/llm.py` or make it configurable.
+7. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+8. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+9. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+10. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+11. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+12. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
+13. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
+14. [Gap 11] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+15. [Gap 1] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+16. [Gap 2] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+17. [Gap 3] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+18. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+19. [Gap 4] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+20. [Gap 5] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+21. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+22. [Gap 7] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
+23. [Gap 8] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
+24. [Gap 9] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+25. [Gap 10] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).

--- a/lua/llm/commands.lua
+++ b/lua/llm/commands.lua
@@ -267,7 +267,7 @@ function M.get_pre_response_message(source, prompt, fragment_paths)
 end
 
 function M.write_context_to_temp_file(context)
-  local temp_file = os.tmpname()
+  local temp_file = vim.fn.tempname()
   local file = io.open(temp_file, "w")
   if not file then
     api.nvim_err_writeln("Failed to create temporary file")
@@ -424,6 +424,9 @@ function M.prompt_with_selection(prompt, fragment_paths, from_visual_mode, bufnr
   end
 
   local temp_file = M.write_context_to_temp_file(selection)
+  if temp_file == "" then
+    return
+  end
 
   local cmd_parts = M.build_base_cmd(fragment_paths)
 
@@ -460,7 +463,7 @@ function M.interactive_prompt_with_fragments(opts)
     visual_selection_text = text.get_visual_selection()
     if visual_selection_text and visual_selection_text ~= "" then
       -- Save selection to a temporary file to treat it like a fragment source
-      visual_selection_temp_file = os.tmpname()
+      visual_selection_temp_file = vim.fn.tempname()
       local file = io.open(visual_selection_temp_file, "w")
       if file then
         file:write(visual_selection_text)

--- a/tests/spec/commands_spec.lua
+++ b/tests/spec/commands_spec.lua
@@ -364,6 +364,15 @@ describe('llm.commands', function() -- This is a new test suite for llm.commands
   end)
 
   describe('prompt_with_selection', function()
+    it('should return early if write_context_to_temp_file returns empty string', function()
+      -- Mock dependencies
+      commands.write_context_to_temp_file = spy.new(function() return '' end)
+
+      commands.prompt_with_selection('test prompt', {}, true, 1)
+
+      assert.spy(api_mock.run_streaming_command).was_not_called()
+    end)
+
     it('should call api.run_streaming_command with the correct arguments', function()
       -- Mock dependencies
       commands.write_context_to_temp_file = spy.new(function() return '/tmp/temp_file' end)


### PR DESCRIPTION
This commit resolves the #1 priority item in BACKLOG.md (Bug 3: Unhandled empty string return from write_context_to_temp_file) along with the highly related Tech Debt 4 (Replace os.tmpname() with secure temporary file creation). The changes ensure that if temp file creation fails, execution halts gracefully, and utilizes vim.fn.tempname() for improved safety and automatic cleanup.

---
*PR created automatically by Jules for task [11962550258905016006](https://jules.google.com/task/11962550258905016006) started by @julwrites*