### PR TITLE
docs: audit and update BACKLOG.md based on llm CLI features

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -42,38 +42,33 @@
 - [Gap 4]: Missing support for Extract Last (`--xl`, `--extract-last`).
 - [Gap 5]: Missing support for System Fragment (`--sf`, `--system-fragment`).
 - [Gap 6]: Missing support for embed-models management (`llm embed-models`).
-- [Gap 7]: Missing support for managing Collections (`llm collections`).
-- [Gap 8]: Missing support for Similarity search (`llm similar`).
 - [Gap 9]: Missing support for explicit Attachment Type (`--at`, `--attachment-type`).
-- [Gap 10]: Missing support for embed-multi (`llm embed-multi`).
 - [Gap 11]: Missing support for Model Aliases (`llm aliases`).
 - [Gap 12]: Missing SSE streaming support in `scripts/llm.py` (responses are parsed as single JSON objects).
 - [Bug 5]: Missing json.JSONDecodeError exception handling in scripts/llm.py.
-- [Gap 13]: Missing support for Embeddings ('llm embed').
+
+- [Bug 6]: Unnecessary manual `os.remove()` for `vim.fn.tempname()` files in `lua/llm/commands.lua` and `lua/llm/managers/schemas_manager.lua`.
 
 ## Ranked Backlog
 1. [Bug 2] - [Medium Impact/Low Effort] - Missing `urllib.error.URLError` exception handling in `scripts/llm.py` for connection errors.
 2. [Bug 4] - [Medium Impact/Low Effort] - Improve API key retrieval robustness in `scripts/llm.py`.
-3. [Gap 12] - [Medium Impact/Medium Effort] - Implement SSE streaming support in `scripts/llm.py` instead of waiting for full response.
-4. [Bug 5] - [Medium Impact/Low Effort] - Handle json.JSONDecodeError in scripts/llm.py.
-5. [Gap 13] - [Medium Impact/Low Effort] - Add support for Embeddings (`llm embed`).
-6. [Tech Debt 1] - [Medium Impact/Low Effort] - Remove hardcoded 60s timeout in `scripts/llm.py` or make it configurable.
-7. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-8. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-9. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-10. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-11. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-12. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
-13. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
-14. [Gap 11] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
-15. [Gap 1] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-16. [Gap 2] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-17. [Gap 3] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-18. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-19. [Gap 4] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-20. [Gap 5] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-21. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
-22. [Gap 7] - [Low Impact/Medium Effort] - Add support for managing Collections (`llm collections`).
-23. [Gap 8] - [Low Impact/Medium Effort] - Add support for Similarity search (`llm similar`).
-24. [Gap 9] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-25. [Gap 10] - [Low Impact/Medium Effort] - Add support for embed-multi (`llm embed-multi`).
+3. [Bug 5] - [Medium Impact/Low Effort] - Handle json.JSONDecodeError in scripts/llm.py.
+4. [Tech Debt 1] - [Medium Impact/Low Effort] - Remove hardcoded 60s timeout in `scripts/llm.py` or make it configurable.
+5. [Gap 12] - [Medium Impact/Medium Effort] - Implement SSE streaming support in `scripts/llm.py` instead of waiting for full response.
+6. [Tech Debt 2] - [Medium Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+7. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+8. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+9. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+10. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+11. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
+12. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
+13. [Gap 1] - [Low Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+14. [Gap 2] - [Low Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+15. [Gap 3] - [Low Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+16. [Tech Debt 3] - [Low Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+17. [Gap 4] - [Low Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+18. [Gap 5] - [Low Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+19. [Gap 9] - [Low Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+20. [Bug 6] - [Low Impact/Low Effort] - Remove unnecessary manual `os.remove()` calls for files generated by `vim.fn.tempname()`.
+21. [Gap 11] - [Low Impact/Low Effort] - Add support for Model Aliases (`llm aliases`).
+22. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).


### PR DESCRIPTION
Audited the `llm-nvim` repository against Simon Willison's `llm` CLI tool to identify gaps, bugs, and optimizations.

Changes:
1. Removed gaps that correspond to CLI-specific/administrative commands not relevant for Neovim (like collections, embeddings, and embed-multi).
2. Documented a new codebase bug (Bug 6) regarding unnecessary `os.remove()` calls for `vim.fn.tempname()` files.
3. Sorted the Ranked Backlog sequentially based on Impact (High > Medium > Low) and Effort (Low > Medium > High).
4. Retained Model Aliases gap per specific instructions.

---
*PR created automatically by Jules for task [3206758531099281659](https://jules.google.com/task/3206758531099281659) started by @julwrites*