### PR TITLE
feat: implement SSE streaming support in scripts/llm.py

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -50,7 +50,6 @@
 - [Gap 5]: Missing support for System Fragment (`--sf`, `--system-fragment`).
 - [Gap 6]: Missing support for embed-models management (`llm embed-models`).
 - [Gap 9]: Missing support for explicit Attachment Type (`--at`, `--attachment-type`).
-- [Gap 12]: Missing SSE streaming support in `scripts/llm.py` (responses are parsed as single JSON objects).
 - [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
 - [Tech Debt 5]: Increase test coverage for templates_manager.lua to >80%.
@@ -61,19 +60,18 @@
 - [Tech Debt 10]: Increase test coverage for tools_manager.lua to >80%.
 
 ## Ranked Backlog
-1. [Gap 12] - [High Impact/Medium Effort] - Implement SSE streaming support in `scripts/llm.py` instead of waiting for full response.
-2. [Tech Debt 2] - [High Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-3. [Tech Debt 3] - [Medium Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-4. [Gap 1] - [Medium Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-5. [Gap 2] - [Medium Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-6. [Gap 3] - [Medium Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-7. [Gap 4] - [Medium Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-8. [Gap 5] - [Medium Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-9. [Gap 9] - [Medium Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-10. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
-11. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-12. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-13. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-14. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-15. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
-16. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+1. [Tech Debt 2] - [High Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
+2. [Tech Debt 3] - [Medium Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+3. [Gap 1] - [Medium Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+4. [Gap 2] - [Medium Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+5. [Gap 3] - [Medium Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+6. [Gap 4] - [Medium Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+7. [Gap 5] - [Medium Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+8. [Gap 9] - [Medium Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+9. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
+10. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+11. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+12. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+13. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+14. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
+15. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).

--- a/scripts/llm.py
+++ b/scripts/llm.py
@@ -8,7 +8,7 @@ import urllib.error
 # Unified LLM Client for Agent Harness
 
 def call_anthropic(prompt, system=None, model="claude-3-5-sonnet-20240620", api_key=None, timeout=60):
-    """Calls Anthropic's Messages API."""
+    """Calls Anthropic's Messages API with streaming."""
     api_key = api_key or os.getenv("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         raise ValueError("ANTHROPIC_API_KEY not set")
@@ -25,7 +25,8 @@ def call_anthropic(prompt, system=None, model="claude-3-5-sonnet-20240620", api_
     data = {
         "model": model,
         "max_tokens": 4096,
-        "messages": messages
+        "messages": messages,
+        "stream": True
     }
 
     if system:
@@ -35,12 +36,24 @@ def call_anthropic(prompt, system=None, model="claude-3-5-sonnet-20240620", api_
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as response:
-            raw_data = response.read().decode("utf-8")
-            try:
-                result = json.loads(raw_data)
-            except json.JSONDecodeError as e:
-                raise Exception(f"Anthropic API JSON Decode Error: {e} - Response: {raw_data}")
-            return result["content"][0]["text"]
+            for line_bytes in response:
+                line = line_bytes.decode("utf-8").strip()
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    data_str = line[6:]
+                    try:
+                        event = json.loads(data_str)
+                        if event.get("type") == "error":
+                            err = event.get("error", {})
+                            raise Exception(f"Anthropic API Error in stream: {err.get('message')}")
+                        if event.get("type") == "content_block_delta":
+                            delta = event.get("delta", {})
+                            if delta.get("type") == "text_delta":
+                                print(delta.get("text", ""), end="", flush=True)
+                    except json.JSONDecodeError:
+                        # Anthropic sometimes sends invalid JSON like partial chunks, but typically SSE is well-formed
+                        pass
+            print() # Print final newline
+            return None
     except urllib.error.HTTPError as e:
         err_body = e.read().decode("utf-8")
         raise Exception(f"Anthropic API Error: {e.code} - {err_body}")
@@ -48,7 +61,7 @@ def call_anthropic(prompt, system=None, model="claude-3-5-sonnet-20240620", api_
         raise Exception(f"Anthropic API Connection Error: {e.reason}")
 
 def call_openai(prompt, system=None, model="gpt-4o", api_key=None, timeout=60):
-    """Calls OpenAI's Chat Completion API."""
+    """Calls OpenAI's Chat Completion API with streaming."""
     api_key = api_key or os.getenv("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise ValueError("OPENAI_API_KEY not set")
@@ -66,19 +79,30 @@ def call_openai(prompt, system=None, model="gpt-4o", api_key=None, timeout=60):
 
     data = {
         "model": model,
-        "messages": messages
+        "messages": messages,
+        "stream": True
     }
 
     req = urllib.request.Request(url, json.dumps(data).encode("utf-8"), headers)
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as response:
-            raw_data = response.read().decode("utf-8")
-            try:
-                result = json.loads(raw_data)
-            except json.JSONDecodeError as e:
-                raise Exception(f"OpenAI API JSON Decode Error: {e} - Response: {raw_data}")
-            return result["choices"][0]["message"]["content"]
+            for line_bytes in response:
+                line = line_bytes.decode("utf-8").strip()
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    data_str = line[6:]
+                    try:
+                        event = json.loads(data_str)
+                        choices = event.get("choices", [])
+                        if choices:
+                            delta = choices[0].get("delta", {})
+                            content = delta.get("content")
+                            if content:
+                                print(content, end="", flush=True)
+                    except json.JSONDecodeError:
+                        pass
+            print() # Print final newline
+            return None
     except urllib.error.HTTPError as e:
         err_body = e.read().decode("utf-8")
         raise Exception(f"OpenAI API Error: {e.code} - {err_body}")
@@ -109,7 +133,8 @@ def main():
 
     try:
         result = complete(args.prompt, provider=args.provider, system=args.system, model=args.model, timeout=args.timeout)
-        print(result)
+        if result is not None:
+            print(result)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import os
+import sys
+import io
 from scripts import llm
 
 class TestLLM(unittest.TestCase):
@@ -8,27 +10,45 @@ class TestLLM(unittest.TestCase):
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_call_anthropic_timeout(self, mock_urlopen):
         mock_response = MagicMock()
-        mock_response.read.return_value = b'{"content": [{"text": "response"}]}'
+        mock_response.__iter__.return_value = [
+            b'data: {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "response"}}\n'
+        ]
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
+        # Capture stdout
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
         llm.call_anthropic("hello", timeout=120)
+
+        sys.stdout = sys.__stdout__
 
         mock_urlopen.assert_called_once()
         _, kwargs = mock_urlopen.call_args
         self.assertEqual(kwargs.get('timeout'), 120)
+        self.assertEqual(captured_output.getvalue().strip(), "response")
 
     @patch('scripts.llm.urllib.request.urlopen')
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
     def test_call_openai_timeout(self, mock_urlopen):
         mock_response = MagicMock()
-        mock_response.read.return_value = b'{"choices": [{"message": {"content": "response"}}]}'
+        mock_response.__iter__.return_value = [
+            b'data: {"choices": [{"delta": {"content": "response"}}]}\n'
+        ]
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
+        # Capture stdout
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
         llm.call_openai("hello", timeout=120)
+
+        sys.stdout = sys.__stdout__
 
         mock_urlopen.assert_called_once()
         _, kwargs = mock_urlopen.call_args
         self.assertEqual(kwargs.get('timeout'), 120)
+        self.assertEqual(captured_output.getvalue().strip(), "response")
 
     @patch('scripts.llm.urllib.request.urlopen')
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
@@ -46,23 +66,33 @@ class TestLLM(unittest.TestCase):
 
     @patch('scripts.llm.urllib.request.urlopen')
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
-    def test_call_anthropic_json_error(self, mock_urlopen):
+    def test_call_anthropic_stream_error(self, mock_urlopen):
         mock_response = MagicMock()
-        mock_response.read.return_value = b'invalid json'
+        mock_response.__iter__.return_value = [
+            b'data: {"type": "error", "error": {"message": "Invalid request"}}\n'
+        ]
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
-        with self.assertRaisesRegex(Exception, "Anthropic API JSON Decode Error: Expecting value: line 1 column 1 .* - Response: invalid json"):
+        with self.assertRaisesRegex(Exception, "Anthropic API Error in stream: Invalid request"):
             llm.call_anthropic("hello")
 
     @patch('scripts.llm.urllib.request.urlopen')
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
-    def test_call_openai_json_error(self, mock_urlopen):
+    def test_call_openai_invalid_json(self, mock_urlopen):
         mock_response = MagicMock()
-        mock_response.read.return_value = b'invalid json'
+        mock_response.__iter__.return_value = [
+            b'data: invalid json\n'
+        ]
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
-        with self.assertRaisesRegex(Exception, "OpenAI API JSON Decode Error: Expecting value: line 1 column 1 .* - Response: invalid json"):
-            llm.call_openai("hello")
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        # Should not raise exception, just ignore invalid json
+        llm.call_openai("hello")
+
+        sys.stdout = sys.__stdout__
+        self.assertEqual(captured_output.getvalue().strip(), "")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented Server-Sent Events (SSE) streaming support in `scripts/llm.py` for both Anthropic and OpenAI providers to remove the wait for full response. 
- Modified Anthropic and OpenAI `call_*` functions to request streaming from the APIs (`"stream": True`).
- Iterates over the `urllib.request.urlopen` HTTP response line by line, isolating standard SSE `data: ` prefixes.
- Extracts standard SSE deltas to stream content to standard out via `print(..., flush=True)`.
- Updated test cases in `tests/test_llm.py` to correctly test the mock iterations of chunks on `sys.stdout`.
- Removed [Gap 12] from `BACKLOG.md` gaps and ranked backlog.

---
*PR created automatically by Jules for task [8902131292549651092](https://jules.google.com/task/8902131292549651092) started by @julwrites*