### PR TITLE
Fix async chunking edge cases in job.lua

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -50,7 +50,6 @@
 - [Gap 5]: Missing support for System Fragment (`--sf`, `--system-fragment`).
 - [Gap 6]: Missing support for embed-models management (`llm embed-models`).
 - [Gap 9]: Missing support for explicit Attachment Type (`--at`, `--attachment-type`).
-- [Tech Debt 2]: Improve async job handling robustness in `job.lua` based on known failure patterns.
 - [Tech Debt 3]: Test coverage missing for `M.interactive_prompt_with_fragments` in `commands.lua`.
 - [Tech Debt 5]: Increase test coverage for templates_manager.lua to >80%.
 - [Tech Debt 6]: Increase test coverage for schemas_manager.lua to >80%.
@@ -60,18 +59,17 @@
 - [Tech Debt 10]: Increase test coverage for tools_manager.lua to >80%.
 
 ## Ranked Backlog
-1. [Tech Debt 2] - [High Impact/Medium Effort] - Enhance async job handling logic in `job.lua` for edge cases.
-2. [Tech Debt 3] - [Medium Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-3. [Gap 1] - [Medium Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-4. [Gap 2] - [Medium Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-5. [Gap 3] - [Medium Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-6. [Gap 4] - [Medium Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-7. [Gap 5] - [Medium Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-8. [Gap 9] - [Medium Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-9. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
-10. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-11. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-12. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-13. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-14. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
-15. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+1. [Tech Debt 3] - [Medium Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+2. [Gap 1] - [Medium Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+3. [Gap 2] - [Medium Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+4. [Gap 3] - [Medium Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+5. [Gap 4] - [Medium Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+6. [Gap 5] - [Medium Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+7. [Gap 9] - [Medium Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+8. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
+9. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+10. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+11. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+12. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+13. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
+14. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).

--- a/lua/llm/core/utils/job.lua
+++ b/lua/llm/core/utils/job.lua
@@ -35,31 +35,31 @@ function M.run(cmd, callbacks)
       if i < #data then
         buffer = buffer .. "\n"
       end
+    end
 
-      local lines = {}
-      while true do
-        local newline_pos = buffer:find('\n')
-        if not newline_pos then break end
+    local lines = {}
+    while true do
+      local newline_pos = buffer:find('\n')
+      if not newline_pos then break end
 
-        local line = buffer:sub(1, newline_pos - 1)
-        if line:sub(-1) == '\r' then
-          line = line:sub(1, -2)
-        end
-        table.insert(lines, line)
-
-        buffer = buffer:sub(newline_pos + 1)
+      local line = buffer:sub(1, newline_pos - 1)
+      if line:sub(-1) == '\r' then
+        line = line:sub(1, -2)
       end
+      table.insert(lines, line)
 
-      if event == "stdout" then
-        stdout_buffer = buffer
-      else
-        stderr_buffer = buffer
-      end
+      buffer = buffer:sub(newline_pos + 1)
+    end
 
-      -- Call handler with complete lines
-      if #lines > 0 then
-        handler(nil, lines)
-      end
+    if event == "stdout" then
+      stdout_buffer = buffer
+    else
+      stderr_buffer = buffer
+    end
+
+    -- Call handler with complete lines
+    if #lines > 0 then
+      handler(nil, lines)
     end
   end
 

--- a/tests/spec/core/utils/job_edge_spec.lua
+++ b/tests/spec/core/utils/job_edge_spec.lua
@@ -1,0 +1,51 @@
+require('tests.spec.spec_helper')
+
+describe('llm.core.utils.job edge cases', function()
+  local job
+
+  before_each(function()
+    package.loaded['llm.core.utils.job'] = nil
+    job = require('llm.core.utils.job')
+  end)
+
+  it('should handle partial lines appropriately for nvim jobstart', function()
+    local on_stdout_spy = spy.new()
+    local captured_job_callbacks
+    vim.fn.jobstart = function(_, callbacks)
+      captured_job_callbacks = callbacks
+      return 1
+    end
+
+    job.run({ 'echo', 'test' }, { on_stdout = on_stdout_spy })
+
+    -- Neovim jobstart on_stdout data format: array of strings.
+    -- All elements except the last indicate a trailing newline.
+    -- The last element is a partial line (or empty string if the line ended in a newline).
+    captured_job_callbacks.on_stdout(0, { 'part', 'ial' }, 'stdout')
+
+    -- This should result in 'part' being a full line, and 'ial' being buffered
+    assert.spy(on_stdout_spy).was.called(1)
+    assert.spy(on_stdout_spy).was.called_with(nil, {'part'})
+
+    captured_job_callbacks.on_stdout(0, { ' is done', '' }, 'stdout')
+    -- 'ial is done' should be a full line. '' means it ended in a newline.
+    assert.spy(on_stdout_spy).was.called(2)
+    assert.spy(on_stdout_spy).was.called_with(nil, {'ial is done'})
+  end)
+
+  it('should handle multiple chunks without newlines correctly', function()
+    local on_stdout_spy = spy.new()
+    local captured_job_callbacks
+    vim.fn.jobstart = function(_, callbacks)
+      captured_job_callbacks = callbacks
+      return 1
+    end
+
+    job.run({ 'echo', 'test' }, { on_stdout = on_stdout_spy })
+    captured_job_callbacks.on_stdout(0, { 'chunk1' }, 'stdout')
+    captured_job_callbacks.on_stdout(0, { 'chunk2' }, 'stdout')
+    captured_job_callbacks.on_stdout(0, { 'chunk3', '' }, 'stdout')
+
+    assert.spy(on_stdout_spy).was.called_with(nil, {'chunk1chunk2chunk3'})
+  end)
+end)


### PR DESCRIPTION
Fixes the handling of async callback chunks in `lua/llm/core/utils/job.lua`. Neovim's `vim.fn.jobstart` `on_stdout` gives a table of strings representing lines. The previous code incorrectly evaluated and appended lines *inside* the array iteration loop, causing issues where intermediate chunks in the `data` array would be prematurely split and fired off as partial responses. Now, the loop first merges all items in `data` (joined by `\n` appropriately) into the core `stdout_buffer` string, and *only then* pulls out the `\n` separated completed lines. This makes it far more robust. Also added regression tests for this exact functionality.

---
*PR created automatically by Jules for task [9610975217654741437](https://jules.google.com/task/9610975217654741437) started by @julwrites*