### PR TITLE
docs: audit llm cli against llm-nvim to document gaps and tech debt

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -8,6 +8,7 @@
 - [Embed-multi]: Store embeddings for multiple strings at once in the... (`llm embed-multi`).
 - [Fragments]: Manage fragments that are stored in the database (`llm fragments`).
 - [Models]: Manage available models (`llm models`).
+- [Logs]: Tools for exploring logged prompts and responses (`llm logs`).
 - [Openai]: Commands for working with OpenAI and OpenAI-compatible APIs (`llm openai`).
 - [Schemas]: Manage stored schemas (`llm schemas`).
 - [Similar]: Return top N similar IDs from a collection using cosine... (`llm similar`).
@@ -15,6 +16,7 @@
 - [Tools]: Manage tools that can be made available to LLMs (`llm tools`).
 - [-s, --system TEXT]: System prompt to use (`-s, --system TEXT`).
 - [-m, --model TEXT]: Model to use (`-m, --model TEXT`).
+- [-d, --database FILE]: Path to log database (`-d, --database FILE`).
 - [-q, --query TEXT]: Use first model matching these strings (`-q, --query TEXT`).
 - [-a, --attachment ATTACHMENT]: Attachment path or URL or - (`-a, --attachment ATTACHMENT`).
 - [-T, --tool TEXT]: Name of a tool to make available to the (`-T, --tool TEXT`).
@@ -31,6 +33,8 @@
 - [-t, --template TEXT]: Template to use (`-t, --template TEXT`).
 - [-p, --param <TEXT TEXT>...]: Parameters for template (`-p, --param <TEXT TEXT>...`).
 - [--no-stream]: Do not stream output (`--no-stream`).
+- [-n, --no-log]: Don't log to database (`-n, --no-log`).
+- [--log]: Log prompt and response to the database (`--log`).
 - [-R, --hide-reasoning]: Hide reasoning output (`-R, --hide-reasoning`).
 - [-c, --continue]: Continue the most recent conversation. (`-c, --continue`).
 - [--cid, --conversation TEXT]: Continue the conversation with the given ID. (`--cid, --conversation TEXT`).
@@ -43,6 +47,10 @@
 - [--json]: Output the response as JSON, same format as (`--json`).
 
 ## Gaps & Tech Debt
+- [Gap 7]: Missing support for Logs (`llm logs`) - exploring logged prompts.
+- [Gap 8]: Missing support for explicit database selection (`-d`, `--database`).
+- [Gap 10]: Missing support for explicit logging overrides (`-n`, `--no-log`, `--log`).
+- [Gap 11]: Missing support for options management (`llm models options`).
 - [Gap 1]: Missing support for Usage tracking (`-u`, `--usage`).
 - [Gap 2]: Missing support for Query Selection (`-q`, `--query`).
 - [Gap 3]: Missing support for Stream Control (`--no-stream`) and Async Execution (`--async`).
@@ -57,19 +65,28 @@
 - [Tech Debt 8]: Increase test coverage for unified_manager.lua to >80%.
 - [Tech Debt 9]: Increase test coverage for plugins_manager.lua to >80%.
 - [Tech Debt 10]: Increase test coverage for tools_manager.lua to >80%.
+- [Tech Debt 12]: Refactor scripts/llm.py to cleanly handle urllib exceptions when JSON is malformed.
+- [Tech Debt 13]: Test coverage missing for `scripts/llm.py` error conditions (JSONDecodeError handling).
 
 ## Ranked Backlog
-1. [Tech Debt 3] - [Medium Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
-2. [Gap 1] - [Medium Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
-3. [Gap 2] - [Medium Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
-4. [Gap 3] - [Medium Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
-5. [Gap 4] - [Medium Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
-6. [Gap 5] - [Medium Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
-7. [Gap 9] - [Medium Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
-8. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
-9. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
-10. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
-11. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
-12. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
-13. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
-14. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+1. [Gap 7] - [High Impact/Medium Effort] - Expose `llm logs` viewing functionality (e.g., in the unified manager).
+2. [Gap 8] - [Medium Impact/Low Effort] - Add support for explicit database selection (`-d`, `--database`).
+3. [Gap 10] - [Medium Impact/Low Effort] - Add support for explicit logging overrides (`-n`, `--no-log`, `--log`).
+4. [Gap 11] - [Low Impact/Medium Effort] - Add support for options management (`llm models options`).
+5. [Tech Debt 3] - [Medium Impact/Low Effort] - Write explicit unit tests for `interactive_prompt_with_fragments` in `commands.lua`.
+6. [Gap 1] - [Medium Impact/Low Effort] - Expose token Usage tracking (`-u`, `--usage`) visually after execution.
+7. [Gap 2] - [Medium Impact/Low Effort] - Enable dynamic Query Selection (`-q`, `--query`).
+8. [Gap 3] - [Medium Impact/Low Effort] - Add options for explicit Async Execution (`--async`) and blocking Stream Control (`--no-stream`).
+9. [Gap 4] - [Medium Impact/Low Effort] - Add support for Extract Last (`--xl`, `--extract-last`).
+10. [Gap 5] - [Medium Impact/Low Effort] - Add support for System Fragment (`--sf`, `--system-fragment`).
+11. [Gap 9] - [Medium Impact/Low Effort] - Add support for explicit Attachment Type (`--at`, `--attachment-type`).
+12. [Tech Debt 5] - [Medium Impact/Medium Effort] - Increase test coverage for templates_manager.lua to >80%.
+13. [Tech Debt 6] - [Medium Impact/Medium Effort] - Increase test coverage for schemas_manager.lua to >80%.
+14. [Tech Debt 7] - [Medium Impact/Medium Effort] - Increase test coverage for models_manager.lua to >80%.
+15. [Tech Debt 8] - [Medium Impact/Medium Effort] - Increase test coverage for unified_manager.lua to >80%.
+16. [Tech Debt 9] - [Medium Impact/Medium Effort] - Increase test coverage for plugins_manager.lua to >80%.
+17. [Tech Debt 10] - [Medium Impact/Medium Effort] - Increase test coverage for tools_manager.lua to >80%.
+18. [Tech Debt 11] - [Medium Impact/Medium Effort] - Increase test coverage for custom_openai.lua to >80%.
+19. [Gap 6] - [Low Impact/Medium Effort] - Add support for embed-models management (`llm embed-models`).
+20. [Tech Debt 12] - [Low Impact/Medium Effort] - Refactor scripts/llm.py to cleanly handle urllib exceptions when JSON is malformed.
+21. [Tech Debt 13] - [Low Impact/Low Effort] - Test coverage missing for `scripts/llm.py` error conditions (JSONDecodeError handling).


### PR DESCRIPTION
Audited the repository against the llm CLI tool to find upstream gaps and bugs/tech debt, producing a re-ranked backlog document.

---
*PR created automatically by Jules for task [18196470151433287178](https://jules.google.com/task/18196470151433287178) started by @julwrites*